### PR TITLE
perf: shrink guest rootfs from 256MB to 16MB

### DIFF
--- a/example/aks/installer/Dockerfile
+++ b/example/aks/installer/Dockerfile
@@ -67,7 +67,7 @@ RUN mkdir -p rootfs/bin rootfs/dev/pts rootfs/dev/shm rootfs/etc \
     echo 'root:x:0:' > rootfs/etc/group && \
     echo '127.0.0.1 localhost' > rootfs/etc/hosts && \
     echo 'nameserver 8.8.8.8' > rootfs/etc/resolv.conf && \
-    genext2fs -b 262144 -d rootfs rootfs.ext4
+    genext2fs -b 16384 -d rootfs rootfs.ext4
 
 # --- Stage 4: Final installer image ---
 FROM debian:bookworm-slim

--- a/guest/rootfs/build-rootfs.sh
+++ b/guest/rootfs/build-rootfs.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 AGENT_BINARY="${1:?Usage: build-rootfs.sh <path-to-cloudhv-agent-binary>}"
 ROOTFS_DIR="rootfs"
 IMAGE_FILE="rootfs.ext4"
-IMAGE_SIZE_MB=64
+IMAGE_SIZE_MB=16
 
 echo "=== Building minimal guest rootfs ==="
 


### PR DESCRIPTION
The ext4 rootfs image contains ~5MB of content (agent + crun + minimal /etc) but was allocated at 256MB (Dockerfile genext2fs) and 64MB (standalone build script). Shrink to 16MB — still 3x headroom.

This reduces:
- Installer image size (~240MB smaller)
- DaemonSet rollout time
- Disk I/O during VM boot