### PR TITLE
fix: release workflow artifact download failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download all artifacts
+      - name: Download shim binary
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/artifacts
+          name: containerd-shim-cloudhv-v1-x86_64-unknown-linux-gnu
+          path: /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-gnu
+
+      - name: Download agent binary
+        uses: actions/download-artifact@v4
+        with:
+          name: cloudhv-agent-x86_64-unknown-linux-musl
+          path: /tmp/artifacts/cloudhv-agent-x86_64-unknown-linux-musl
+
+      - name: Download kernel
+        uses: actions/download-artifact@v4
+        with:
+          name: vmlinux
+          path: /tmp/artifacts/vmlinux
+
+      - name: Download rootfs
+        uses: actions/download-artifact@v4
+        with:
+          name: rootfs
+          path: /tmp/artifacts/rootfs
 
       - name: Prepare image contents
         run: |
@@ -168,10 +187,29 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download all artifacts
+      - name: Download shim binary
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/artifacts
+          name: containerd-shim-cloudhv-v1-x86_64-unknown-linux-gnu
+          path: /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-gnu
+
+      - name: Download agent binary
+        uses: actions/download-artifact@v4
+        with:
+          name: cloudhv-agent-x86_64-unknown-linux-musl
+          path: /tmp/artifacts/cloudhv-agent-x86_64-unknown-linux-musl
+
+      - name: Download kernel
+        uses: actions/download-artifact@v4
+        with:
+          name: vmlinux
+          path: /tmp/artifacts/vmlinux
+
+      - name: Download rootfs
+        uses: actions/download-artifact@v4
+        with:
+          name: rootfs
+          path: /tmp/artifacts/rootfs
 
       - name: Prepare release assets
         run: |


### PR DESCRIPTION
The v0.1.0 release failed because `actions/download-artifact@v4` downloaded ALL artifacts including Docker buildx internal metadata (`devigned~containerd-cloudhypervisor~WKYU7N.dockerbuild`), which failed to extract after 5 retries.

Fix: download each artifact by name explicitly instead of using a blanket download. This skips the buildx metadata artifact that was causing the failure.