### PR TITLE
fix: installer image missing curl, Helm chart tag prefix

### DIFF
--- a/.github/Dockerfile.installer
+++ b/.github/Dockerfile.installer
@@ -5,6 +5,10 @@
 
 FROM debian:bookworm-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY opt/cloudhv/ /opt/cloudhv/
 
 RUN chmod +x /opt/cloudhv/containerd-shim-cloudhv-v1 \

--- a/charts/cloudhv-installer/templates/daemonset.yaml
+++ b/charts/cloudhv-installer/templates/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       hostPID: true
       containers:
         - name: installer
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             privileged: true


### PR DESCRIPTION
Fixes two issues discovered during v0.1.0 AKS deployment:

1. **Dockerfile.installer missing curl**: install.sh downloads Cloud Hypervisor using curl, but debian:bookworm-slim doesn't include it
2. **Helm chart tag mismatch**: image tagged as `v0.1.0` but chart defaulted to `0.1.0` (without v prefix)