### PR TITLE
fix: build shim as static musl binary for glibc compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             package: containerd-shim-cloudhv
             artifact: containerd-shim-cloudhv-v1
           - target: x86_64-unknown-linux-musl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             package: containerd-shim-cloudhv
             artifact: containerd-shim-cloudhv-v1
           - target: x86_64-unknown-linux-musl
@@ -115,8 +115,8 @@ jobs:
       - name: Download shim binary
         uses: actions/download-artifact@v4
         with:
-          name: containerd-shim-cloudhv-v1-x86_64-unknown-linux-gnu
-          path: /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-gnu
+          name: containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl
+          path: /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl
 
       - name: Download agent binary
         uses: actions/download-artifact@v4
@@ -139,7 +139,7 @@ jobs:
       - name: Prepare image contents
         run: |
           mkdir -p /tmp/image-root/opt/cloudhv
-          cp /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-gnu/containerd-shim-cloudhv-v1 \
+          cp /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl/containerd-shim-cloudhv-v1 \
             /tmp/image-root/opt/cloudhv/
           cp /tmp/artifacts/vmlinux/vmlinux /tmp/image-root/opt/cloudhv/
           cp /tmp/artifacts/rootfs/rootfs.ext4 /tmp/image-root/opt/cloudhv/
@@ -190,8 +190,8 @@ jobs:
       - name: Download shim binary
         uses: actions/download-artifact@v4
         with:
-          name: containerd-shim-cloudhv-v1-x86_64-unknown-linux-gnu
-          path: /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-gnu
+          name: containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl
+          path: /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl
 
       - name: Download agent binary
         uses: actions/download-artifact@v4
@@ -214,7 +214,7 @@ jobs:
       - name: Prepare release assets
         run: |
           mkdir -p /tmp/release
-          cp /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-gnu/containerd-shim-cloudhv-v1 \
+          cp /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl/containerd-shim-cloudhv-v1 \
             /tmp/release/containerd-shim-cloudhv-v1-linux-amd64
           cp /tmp/artifacts/cloudhv-agent-x86_64-unknown-linux-musl/cloudhv-agent \
             /tmp/release/cloudhv-agent-linux-amd64


### PR DESCRIPTION
The shim built with `x86_64-unknown-linux-gnu` requires GLIBC_2.39, but AKS nodes (Ubuntu 22.04) have GLIBC 2.35. This caused `GLIBC_2.39 not found` when creating pod sandboxes.

Fix: build with `x86_64-unknown-linux-musl` (statically linked) in both CI and release workflows. Static binaries run on any Linux kernel.