### PR TITLE
fix: exclude Docker buildx artifacts from release downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/artifacts
+          pattern: '!(*dockerbuild*)'
 
       - name: Prepare image contents (amd64)
         run: |
@@ -254,6 +255,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/artifacts
+          pattern: '!(*dockerbuild*)'
 
       - name: Prepare release assets
         run: |


### PR DESCRIPTION
The `docker/build-push-action` creates internal `.dockerbuild` artifacts that cause `download-artifact@v4` to fail when downloading all artifacts (transient download failures on artifacts we don't need). Filter them out with a negative glob pattern in both the installer-image and release jobs.

Fixes the v0.2.0 release failure.