### PR TITLE
fix: use explicit artifact downloads in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,13 +159,53 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download all artifacts
+      - name: Download shim (x86_64)
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/artifacts
-          pattern: '!(*dockerbuild*)'
+          name: containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl
+          path: /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl
 
-      - name: Prepare image contents (amd64)
+      - name: Download shim (aarch64)
+        uses: actions/download-artifact@v4
+        with:
+          name: containerd-shim-cloudhv-v1-aarch64-unknown-linux-musl
+          path: /tmp/artifacts/containerd-shim-cloudhv-v1-aarch64-unknown-linux-musl
+
+      - name: Download kernel (x86_64)
+        uses: actions/download-artifact@v4
+        with:
+          name: vmlinux-x86_64
+          path: /tmp/artifacts/vmlinux-x86_64
+
+      - name: Download kernel (aarch64)
+        uses: actions/download-artifact@v4
+        with:
+          name: vmlinux-aarch64
+          path: /tmp/artifacts/vmlinux-aarch64
+
+      - name: Download rootfs (x86_64)
+        uses: actions/download-artifact@v4
+        with:
+          name: rootfs-x86_64
+          path: /tmp/artifacts/rootfs-x86_64
+
+      - name: Download rootfs (aarch64)
+        uses: actions/download-artifact@v4
+        with:
+          name: rootfs-aarch64
+          path: /tmp/artifacts/rootfs-aarch64
+
+      - name: Download virtiofsd (x86_64)
+        uses: actions/download-artifact@v4
+        with:
+          name: virtiofsd-x86_64
+          path: /tmp/artifacts/virtiofsd-x86_64
+
+      - name: Download virtiofsd (aarch64)
+        uses: actions/download-artifact@v4
+        with:
+          name: virtiofsd-aarch64
+          path: /tmp/artifacts/virtiofsd-aarch64
         run: |
           mkdir -p /tmp/image-root-amd64/opt/cloudhv
           cp /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl/containerd-shim-cloudhv-v1 \
@@ -251,13 +291,53 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download all artifacts
+      - name: Download shim (x86_64)
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/artifacts
-          pattern: '!(*dockerbuild*)'
+          name: containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl
+          path: /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl
 
-      - name: Prepare release assets
+      - name: Download shim (aarch64)
+        uses: actions/download-artifact@v4
+        with:
+          name: containerd-shim-cloudhv-v1-aarch64-unknown-linux-musl
+          path: /tmp/artifacts/containerd-shim-cloudhv-v1-aarch64-unknown-linux-musl
+
+      - name: Download agent (x86_64)
+        uses: actions/download-artifact@v4
+        with:
+          name: cloudhv-agent-x86_64-unknown-linux-musl
+          path: /tmp/artifacts/cloudhv-agent-x86_64-unknown-linux-musl
+
+      - name: Download agent (aarch64)
+        uses: actions/download-artifact@v4
+        with:
+          name: cloudhv-agent-aarch64-unknown-linux-musl
+          path: /tmp/artifacts/cloudhv-agent-aarch64-unknown-linux-musl
+
+      - name: Download kernel (x86_64)
+        uses: actions/download-artifact@v4
+        with:
+          name: vmlinux-x86_64
+          path: /tmp/artifacts/vmlinux-x86_64
+
+      - name: Download kernel (aarch64)
+        uses: actions/download-artifact@v4
+        with:
+          name: vmlinux-aarch64
+          path: /tmp/artifacts/vmlinux-aarch64
+
+      - name: Download rootfs (x86_64)
+        uses: actions/download-artifact@v4
+        with:
+          name: rootfs-x86_64
+          path: /tmp/artifacts/rootfs-x86_64
+
+      - name: Download rootfs (aarch64)
+        uses: actions/download-artifact@v4
+        with:
+          name: rootfs-aarch64
+          path: /tmp/artifacts/rootfs-aarch64
         run: |
           mkdir -p /tmp/release
           # x86_64


### PR DESCRIPTION
The `download-artifact@v4` negation pattern `!(*dockerbuild*)` doesn't filter out Docker buildx internal artifacts, causing transient download failures that break the release.

Replace with explicit per-artifact downloads by name. More verbose but completely reliable — only downloads the 8-10 artifacts we actually need.