### PR TITLE
fix: repair missing step separators in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,8 @@ jobs:
         with:
           name: virtiofsd-aarch64
           path: /tmp/artifacts/virtiofsd-aarch64
+
+      - name: Prepare image contents (amd64)
         run: |
           mkdir -p /tmp/image-root-amd64/opt/cloudhv
           cp /tmp/artifacts/containerd-shim-cloudhv-v1-x86_64-unknown-linux-musl/containerd-shim-cloudhv-v1 \
@@ -338,6 +340,8 @@ jobs:
         with:
           name: rootfs-aarch64
           path: /tmp/artifacts/rootfs-aarch64
+
+      - name: Prepare release assets
         run: |
           mkdir -p /tmp/release
           # x86_64


### PR DESCRIPTION
Two download-artifact steps were missing the step separator before the next step's `run:` block, creating invalid GitHub Actions steps (both `with` and `run` in one step). This caused the entire release workflow to fail with 0 jobs evaluated.

Critical fix — the release workflow is completely broken without this.