### PR TITLE
fix: restore container log forwarding to containerd FIFOs

### DIFF
--- a/crates/agent/src/mount.rs
+++ b/crates/agent/src/mount.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 #[cfg(target_os = "linux")]
 use log::debug;
 use log::info;
+use log::warn;
 
 #[cfg(target_os = "linux")]
 use cloudhv_common::{VIRTIOFS_GUEST_MOUNT, VIRTIOFS_TAG};
@@ -100,22 +101,38 @@ pub fn mount_virtiofs() -> Result<()> {
     std::fs::create_dir_all(mount_point)
         .with_context(|| format!("failed to create mount point: {mount_point}"))?;
 
-    info!(
-        "mounting virtio-fs: tag={} at {}",
-        VIRTIOFS_TAG, mount_point
-    );
-
-    mount(
-        Some(VIRTIOFS_TAG),
-        mount_point,
-        Some("virtiofs"),
-        MsFlags::empty(),
-        None::<&str>,
-    )
-    .with_context(|| format!("failed to mount virtio-fs tag={VIRTIOFS_TAG} at {mount_point}"))?;
-
-    info!("virtio-fs mounted at {}", mount_point);
-    Ok(())
+    // Retry the mount — the virtio-fs device may not be ready immediately
+    // after the kernel boots (vhost-user handshake with virtiofsd is async).
+    for attempt in 1..=10 {
+        match mount(
+            Some(VIRTIOFS_TAG),
+            mount_point,
+            Some("virtiofs"),
+            MsFlags::empty(),
+            None::<&str>,
+        ) {
+            Ok(()) => {
+                info!("virtio-fs mounted at {} (attempt {})", mount_point, attempt);
+                return Ok(());
+            }
+            Err(e) if attempt < 10 => {
+                warn!(
+                    "virtio-fs mount attempt {}/10 failed: {} (retrying in 100ms)",
+                    attempt, e
+                );
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            Err(e) => {
+                anyhow::bail!(
+                    "failed to mount virtio-fs tag={} at {} after 10 attempts: {}",
+                    VIRTIOFS_TAG,
+                    mount_point,
+                    e
+                );
+            }
+        }
+    }
+    unreachable!()
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/crates/shim/src/instance.rs
+++ b/crates/shim/src/instance.rs
@@ -62,6 +62,8 @@ pub struct CloudHvInstance {
     exit: WaitableCell<(u32, DateTime<Utc>)>,
     is_sandbox: bool,
     sandbox_id: String,
+    stdout: PathBuf,
+    stderr: PathBuf,
 }
 
 impl Instance for CloudHvInstance {
@@ -77,6 +79,8 @@ impl Instance for CloudHvInstance {
             exit: WaitableCell::new(),
             is_sandbox,
             sandbox_id,
+            stdout: cfg.stdout.clone(),
+            stderr: cfg.stderr.clone(),
         })
     }
 
@@ -394,6 +398,33 @@ impl CloudHvInstance {
 
         vm_state.container_count.fetch_add(1, Ordering::SeqCst);
 
+        // Forward container stdout/stderr from virtio-fs files to containerd FIFOs.
+        // This makes `kubectl logs` and `crictl logs` work.
+        // We open the FIFOs synchronously here (before start returns) so containerd's
+        // reader sees an active writer and doesn't get EOF.
+        let stdout_src = io_dir.join("stdout");
+        let stderr_src = io_dir.join("stderr");
+        let stdout_dst = self.stdout.to_string_lossy().to_string();
+        let stderr_dst = self.stderr.to_string_lossy().to_string();
+        if !stdout_dst.is_empty() {
+            let fifo = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&stdout_dst);
+            if let Ok(fifo) = fifo {
+                tokio::spawn(forward_output(stdout_src, fifo));
+            }
+        }
+        if !stderr_dst.is_empty() {
+            let fifo = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&stderr_dst);
+            if let Ok(fifo) = fifo {
+                tokio::spawn(forward_output(stderr_src, fifo));
+            }
+        }
+
         // Background task monitors container exit via agent WaitContainer RPC
         let exit = self.exit.clone();
         let cid = container_id.to_string();
@@ -416,6 +447,58 @@ impl CloudHvInstance {
         let pid = start_resp.pid;
         info!("started container {} pid={}", container_id, pid);
         Ok(pid)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// I/O forwarding
+// ---------------------------------------------------------------------------
+
+/// Forward container output from a virtio-fs file to an already-opened containerd FIFO.
+///
+/// The agent writes crun's stdout/stderr to files in the virtio-fs shared
+/// directory. This task tails the file and writes to the FIFO so that
+/// `crictl logs` and `kubectl logs` work.
+async fn forward_output(src: std::path::PathBuf, fifo: std::fs::File) {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    // Wait for the source file to appear (agent creates it on container start)
+    for _ in 0..100 {
+        if src.exists() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    let src_file = match tokio::fs::File::open(&src).await {
+        Ok(f) => f,
+        Err(e) => {
+            info!("I/O forward: can't open source {}: {e}", src.display());
+            return;
+        }
+    };
+
+    let mut reader = BufReader::new(src_file);
+    let mut writer = tokio::fs::File::from_std(fifo);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) => {
+                // EOF — file may still be written to, poll
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                if tokio::fs::metadata(&src).await.is_err() {
+                    break; // File removed, stop
+                }
+            }
+            Ok(_) => {
+                if writer.write_all(line.as_bytes()).await.is_err() {
+                    break; // FIFO reader disconnected
+                }
+            }
+            Err(_) => break,
+        }
     }
 }
 


### PR DESCRIPTION
Fixes container log forwarding — `kubectl logs` and `crictl logs` now work.

## Root Causes (two issues)

**1. Agent: virtio-fs mount race condition**
The agent tried to mount virtio-fs once during init. On fast kernel boots, the virtio-fs device was not ready yet (vhost-user handshake incomplete), so the mount silently failed. Since `/containers/` existed on the rootfs, `File::create` succeeded but wrote locally instead of to the shared directory.

Fix: retry loop (up to 10 attempts, 100ms apart) in `mount_virtiofs()`.

**2. Shim: forward_output removed during dead code cleanup**
The function that tails virtio-fs stdout/stderr files and pipes them to containerd FIFOs was deleted in PR #27. Restored with fix: FIFOs opened synchronously during `start()` with read+write mode.

## Full Pipeline (verified working)

```
crun stdout → File in virtio-fs (/containers/io/<id>/stdout)
            → visible on host (shared/io/<id>/stdout)
            → forward_output tails → containerd FIFO
            → crictl logs / kubectl logs
```

## Verified Output

```
=== crictl logs ===
HELLO_STDOUT
HELLO_STDERR

=== CRI log file ===
2026-03-12T19:08:47.938340794Z stdout F HELLO_STDOUT
2026-03-12T19:08:47.938341261Z stderr F HELLO_STDERR
```

## Changes

- `crates/agent/src/mount.rs`: Retry loop for `mount_virtiofs()` (10 attempts, 100ms delay)
- `crates/shim/src/instance.rs`: Restore `forward_output`, store stdout/stderr paths, open FIFOs synchronously in `start()`