### PR TITLE
perf: optimize container startup latency

### DIFF
--- a/crates/agent/src/container.rs
+++ b/crates/agent/src/container.rs
@@ -392,6 +392,16 @@ impl ContainerManager {
                         code,
                         exited_at: chrono::Utc::now().to_rfc3339(),
                     }));
+
+                    // Write exit file to virtio-fs for fast host-side detection
+                    let exit_path = format!(
+                        "{}/io/{}/exit",
+                        cloudhv_common::VIRTIOFS_GUEST_MOUNT,
+                        container_id_owned
+                    );
+                    if let Err(e) = std::fs::write(&exit_path, code.to_string()) {
+                        warn!("failed to write exit file {}: {}", exit_path, e);
+                    }
                 }
                 Err(e) => {
                     error!("container wait error: id={} err={}", container_id_owned, e);
@@ -399,6 +409,16 @@ impl ContainerManager {
                         code: 137,
                         exited_at: chrono::Utc::now().to_rfc3339(),
                     }));
+
+                    // Write exit file with error code for host-side detection
+                    let exit_path = format!(
+                        "{}/io/{}/exit",
+                        cloudhv_common::VIRTIOFS_GUEST_MOUNT,
+                        container_id_owned
+                    );
+                    if let Err(e) = std::fs::write(&exit_path, "137") {
+                        warn!("failed to write exit file {}: {}", exit_path, e);
+                    }
                 }
             }
         });

--- a/crates/shim/src/instance.rs
+++ b/crates/shim/src/instance.rs
@@ -460,24 +460,45 @@ impl CloudHvInstance {
             None
         };
 
-        // Background task monitors container exit via agent WaitContainer RPC.
-        // When the container exits, abort the forward_output tasks to release
-        // the FIFO file descriptors — shimkit needs them closed for exit detection.
+        // Watch for exit file in virtio-fs shared directory (fast path),
+        // with WaitContainer RPC as fallback if the exit file never appears.
         let exit = self.exit.clone();
         let cid = container_id.to_string();
-        let agent_clone = agent.clone();
+        let exit_file = io_dir.join("exit");
+        let fallback_agent = agent.clone();
         tokio::spawn(async move {
-            let mut wait_req = cloudhv_proto::WaitContainerRequest::new();
-            wait_req.container_id = cid.clone();
-            let ctx = ttrpc::context::with_duration(std::time::Duration::from_secs(86400));
-            let exit_code = match agent_clone.wait_container(ctx, &wait_req).await {
-                Ok(resp) => resp.exit_status,
-                Err(e) => {
-                    info!("wait_container RPC error for {}: {e}", cid);
-                    137
+            // Fast path: poll for exit file (10ms resolution, near-instant via virtio-fs)
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+            let exit_code = loop {
+                if exit_file.exists() {
+                    let code = std::fs::read_to_string(&exit_file)
+                        .ok()
+                        .and_then(|s| s.trim().parse::<u32>().ok())
+                        .unwrap_or(137);
+                    info!("container {} exited with code {} (exit file)", cid, code);
+                    break code;
                 }
+                if tokio::time::Instant::now() >= deadline {
+                    // Fallback: WaitContainer RPC (handles agent panic / missing exit file)
+                    info!(
+                        "container {}: exit file not found after 30s, falling back to RPC",
+                        cid
+                    );
+                    let mut wait_req = cloudhv_proto::WaitContainerRequest::new();
+                    wait_req.container_id = cid.clone();
+                    let ctx = ttrpc::context::with_duration(std::time::Duration::from_secs(600));
+                    let code = match fallback_agent.wait_container(ctx, &wait_req).await {
+                        Ok(resp) => resp.exit_status,
+                        Err(e) => {
+                            info!("wait_container RPC fallback error for {}: {e}", cid);
+                            137
+                        }
+                    };
+                    info!("container {} exited with code {} (RPC fallback)", cid, code);
+                    break code;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             };
-            info!("container {} exited with code {}", cid, exit_code);
 
             // Abort I/O forwarding to close FIFOs
             if let Some(h) = stdout_handle {
@@ -650,7 +671,7 @@ fn create_rootfs_disk_image(
     let status = Command::new("cp")
         .args(["-a", "--"])
         .arg(format!("{}/.", rootfs_path.display()))
-        .arg(&staging.join("rootfs"))
+        .arg(staging.join("rootfs"))
         .status()
         .context("cp rootfs to staging dir")?;
     if !status.success() {


### PR DESCRIPTION
Part of #30

## Optimizations

### 1. Lazy agent connect — sandbox boot 2.4x faster
Defers the vsock agent connection from sandbox boot to first container start.
The VM boots and returns immediately (~102ms vs 248ms before). The agent
connection cost (153ms) moves to `start_container()` where it is paid once
and cached via `OnceCell`.

### 2. Loopback-free disk image — eliminates VFS lock contention
Replaces `mkfs.ext4` → `mount -o loop` → `cp` → `umount` with `mkfs.ext4 -d`
which populates the ext4 image directly from a directory. Eliminates loopback
mount kernel VFS lock that serialized concurrent container starts at scale.

### 3. Virtio-fs exit file detection — consistent ~110ms exit latency
Agent writes exit code to `shared/io/<id>/exit` via virtio-fs. Shim polls
this file every 10ms instead of using WaitContainer ttrpc RPC. Falls back
to RPC after 30s if the exit file never appears (handles agent panics).

## Results (hl-dev, 5-run avg excluding cold start)

| Phase | v0.3.2 | Optimized | Change |
|-------|:------:|:---------:|:------:|
| Sandbox | 248ms | **107ms** | **-57%** |
| Create | 61ms | 66ms | ~same |
| Start | 127ms | 207ms | +80ms (lazy connect) |
| Exit | 107ms | **118ms** | consistent |
| **Total** | **541ms** | **497ms** | **-8%** |

Sandbox+Start combined: 375ms → 314ms (**-16%**)

## Commits

1. `perf: lazy agent connect and loopback-free disk image creation`
2. `perf: replace WaitContainer RPC with virtio-fs exit file polling`