### PR TITLE
docs: update all documentation for block-device-only architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ that runs container workloads inside lightweight microVMs with maximum density a
 
 ## Highlights
 
-- **~300ms cold start**, or **~30ms from snapshot restore** with pre-warmed pool
+- **~420ms end-to-end container lifecycle (cold boot)
 - **VM isolation** — each pod runs in its own Cloud Hypervisor microVM with dedicated kernel
 - **Block device rootfs** — container images delivered as hot-plugged virtio-blk disks (no FUSE)
 - **Dual hypervisor** — same binary runs on KVM (Linux) and MSHV (Azure/Hyper-V)
@@ -24,7 +24,7 @@ migration, consider [Kata Containers](https://katacontainers.io/) instead.
 
 | | containerd-cloudhypervisor | Kata Containers |
 | --- | --- | --- |
-| **Cold start** | ~300ms boot, ~30ms snapshot restore | ~500ms–1s |
+| **Cold start** | ~420ms e2e (cold boot) | ~500ms–1s |
 | **Shim binary** | 2.4 MB | ~50 MB |
 | **Guest rootfs** | 16 MB (agent + crun) | ~150 MB |
 | **Language** | Rust | Go |
@@ -52,7 +52,6 @@ sudo tee /opt/cloudhv/config.json > /dev/null <<EOF
   "kernel_args": "console=hvc0 root=/dev/vda rw quiet init=/init net.ifnames=0",
   "default_vcpus": 1,
   "default_memory_mb": 512,
-  "pool_size": 2,
   "max_containers_per_vm": 5
 }
 EOF
@@ -65,9 +64,9 @@ sudo cargo test -p containerd-shim-cloudhv --test integration -- --nocapture --t
 
 See the **[docs/](docs/)** folder for detailed documentation:
 
-- **[Architecture](docs/architecture.md)** — system design, networking, container rootfs, snapshot/restore
+- **[Architecture](docs/architecture.md)** — system design, networking, container rootfs, block-device-only architecture
 - **[Configuration](docs/configuration.md)** — runtime config reference and pod annotation overrides
-- **[Performance](docs/performance.md)** — benchmarks, cold boot, snapshot restore, resource overhead
+- **[Performance](docs/performance.md)** — benchmarks, cold boot, resource overhead, vsock logs
 - **[Development](docs/development.md)** — building, testing, contributing, code quality standards
 
 ## Examples

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,9 @@
 
 | Document | Description |
 |----------|-------------|
-| [Architecture](architecture.md) | System design, networking, container rootfs, logging, snapshot/restore |
+| [Architecture](architecture.md) | System design, networking, container rootfs, logging, block-device-only architecture, vsock logs |
 | [Configuration](configuration.md) | Runtime config reference and pod annotation overrides |
-| [Performance](performance.md) | Benchmarks, cold boot, snapshot restore, resource overhead |
+| [Performance](performance.md) | Benchmarks, cold boot, resource overhead, vsock logs |
 | [Development](development.md) | Building, testing, contributing, code quality standards |
 | [Releasing](releasing.md) | Release process, Helm chart, GHCR artifacts |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,35 +70,24 @@ Following the same approach as [firecracker-containerd](https://github.com/firec
 
 This avoids FUSE in the container data path and enables proper `pivot_root`.
 
-## Volumes (CSI, ConfigMap, Secret)
+## Volumes
 
-Kubernetes volumes are transported into the VM using a dual-path approach
-optimized for each volume type:
+| Volume Type | Status | Transport |
+|-------------|--------|-----------|
+| Block PVC (raw) | ✅ Supported | `vm.add-disk` hot-plug → `/dev/vdX` direct I/O |
+| Filesystem PVC | ❌ Not yet supported | Requires new transport (virtio-fs removed) |
+| ConfigMap | ❌ Not yet supported | Requires new transport |
+| Secret | ❌ Not yet supported | Requires new transport |
+| emptyDir | ❌ Not yet supported | Requires new transport |
 
-| Volume Type | Host Form | Transport | Guest Access | Writes Persist |
-|-------------|-----------|-----------|-------------|----------------|
-| Block PVC (raw) | `/dev/sdX` | `vm.add-disk` hot-plug | `/dev/vdX` direct I/O | Yes |
-| Filesystem PVC | directory | virtio-fs bind mount | bind mount | Yes |
-| ConfigMap | directory | virtio-fs bind mount | bind mount | No (read-only) |
-| Secret | directory | virtio-fs bind mount | bind mount | No (read-only) |
-| emptyDir | directory | virtio-fs bind mount | bind mount | Yes (pod lifetime) |
+Block device PVCs are hot-plugged into the VM via `vm.add-disk` and mounted
+directly by the guest agent. The agent discovers new block devices via
+`/sys/block` scanning and mounts them at the requested path.
 
-### How It Works
-
-1. The shim reads the OCI spec's mounts array from the container bundle
-2. For each volume mount (skipping system mounts like `/proc`, `/dev`, `/sys`):
-   - **Block devices**: detected via `is_block_device()`, hot-plugged into the VM
-     via `vm.add-disk`, agent discovers and mounts the new `/dev/vdX` device
-   - **Filesystem paths**: bind-mounted into the virtio-fs shared directory,
-     giving the guest a live view of the host data through virtio-fs
-3. Volume metadata (destination, source, type, readonly) is passed to the agent
-   via the `CreateContainer` RPC
-4. The agent injects the volumes as mounts in the adapted OCI spec
-5. `crun` mounts them at the expected paths inside the container
-
-Block device passthrough avoids FUSE overhead for I/O-intensive workloads.
-Filesystem sharing via virtio-fs preserves write persistence — changes inside
-the container propagate back to the host PV.
+Filesystem-based volumes (ConfigMaps, Secrets, emptyDir, filesystem PVCs) previously
+used virtio-fs, which has been removed in favor of a block-device-only architecture.
+A new transport mechanism for these volume types is planned — likely baking them
+into the container's rootfs disk image or using a dedicated block device per volume.
 
 ## Networking
 
@@ -120,42 +109,19 @@ network, fully transparent to CNI and Kubernetes services.
 
 ## Container Logs
 
-Container stdout/stderr flows from the guest to `kubectl logs` without any agent-side
-log infrastructure:
+Container stdout/stderr flows from the guest to `kubectl logs` via vsock:
 
-1. `crun` inside the VM writes stdout/stderr to files on the virtio-fs shared directory
-2. The host shim tails these files and forwards lines to containerd's stdio FIFOs
-3. containerd delivers them as standard container logs (`crictl logs`, `kubectl logs`)
+1. The guest agent captures `crun` stdout/stderr via piped file descriptors
+2. The agent buffers output and serves it via the `GetContainerLogs` ttrpc RPC
+3. The host shim polls `GetContainerLogs` every 10ms and writes to containerd's stdio FIFOs
+4. containerd delivers them as standard container logs (`crictl logs`, `kubectl logs`)
+
+This approach uses no shared filesystem — all log data flows over the existing
+vsock connection between the shim and the guest agent.
 
 Infrastructure errors (VM boot failures, API errors, disk hot-plug issues) are logged
 via the shim's own logger and appear in the containerd log (`journalctl -u containerd`),
 keeping operator diagnostics separate from application output.
-
-## Snapshot/Restore
-
-The `SnapshotManager` captures a **golden snapshot** of a fully-booted VM (kernel up,
-agent running) and restores copies in ~30ms instead of cold-booting (~300ms):
-
-1. **Golden snapshot creation** (one-time, ~115ms): boot a minimal VM (disk + vsock,
-   no virtiofs), verify agent health, pause, snapshot to disk, shut down
-2. **Restore** (~32ms): start new CH process, restore from snapshot with per-instance
-   config.json (rewritten vsock paths, symlinked memory file), resume
-3. **Post-restore networking** (~50ms): hot-add virtio-net via `vm.add-net` API
-
-The golden snapshot excludes virtiofs because the vhost-user protocol state cannot
-reconnect to a fresh virtiofsd after restore. Container operations that need the
-shared directory (disk image hot-plug, I/O file forwarding) use full VM boot.
-The VM pool uses snapshot restore when a golden snapshot is available, falling back
-to cold boot transparently.
-
-process instead of a separate daemon. This eliminates ~5 MB RSS per VM and reduces
-virtiofsd startup from ~10ms to ~277µs. The vhost-user socket is still created —
-Cloud Hypervisor connects to it the same way — but no child process is spawned.
-
-```bash
-```
-
-Requires `libseccomp-dev` and `libcap-ng-dev` on Linux.
 
 ## Dynamic Memory Management
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,6 @@ The shim loads its configuration from `/opt/cloudhv/config.json` at startup.
 | `kernel_args` | `console=hvc0 root=/dev/vda rw quiet init=/init net.ifnames=0` | Guest kernel cmdline (see [Architecture Notes](#architecture-notes)) |
 | `default_vcpus` | `1` | Boot vCPUs per VM |
 | `default_memory_mb` | `128` | Boot memory in MiB |
-| `pool_size` | `2` | Pre-warmed VM pool size (0 = disabled) |
 | `max_containers_per_vm` | `5` | Max containers sharing a VM |
 | `hotplug_memory_mb` | `0` | Hotpluggable memory (0 = disabled) |
 | `hotplug_method` | `acpi` | `acpi` or `virtio-mem` |
@@ -28,7 +27,6 @@ The shim loads its configuration from `/opt/cloudhv/config.json` at startup.
   "kernel_args": "console=hvc0 root=/dev/vda rw quiet init=/init net.ifnames=0",
   "default_vcpus": 1,
   "default_memory_mb": 512,
-  "pool_size": 2,
   "max_containers_per_vm": 5,
   "tpm_enabled": false
 }
@@ -49,8 +47,6 @@ The shim loads its configuration from `/opt/cloudhv/config.json` at startup.
 - The kernel config used to build the guest kernel also differs per architecture:
   `guest/kernel/configs/microvm.config` for x86_64 and
   `guest/kernel/configs/microvm-aarch64.config` for ARM64.
-- `pool_size` controls how many VMs are pre-booted and kept ready. Set to `0` to
-  disable pooling (every pod gets a cold-booted VM).
 - `max_containers_per_vm` limits density. Each container gets its own hot-plugged
   disk and mount + PID namespace isolation within the shared VM.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,60 +1,30 @@
 # Performance
 
-All measurements from CI (GitHub Actions, ubuntu-latest, KVM via nested virtualization).
+All measurements from hl-dev (Azure D8s_v5, KVM, Cloud Hypervisor v44.0,
+containerd 2.2.2).
 
 ## Cold Boot
 
-Full VM lifecycle from scratch — kernel boots, agent starts, ttrpc connects.
+Full VM lifecycle from scratch — kernel boots, agent starts, container runs.
 
 | Phase | Latency |
 |-------|---------|
-| Shim setup (new + prepare) | **~0.1ms** |
-| Cloud Hypervisor startup | **~6ms** |
-| VM create + boot (CH API) | **~16ms** |
-| Guest boot + agent ready | **~231ms** |
-| ttrpc connect | **~0.3ms** |
-| **Total cold start** | **~280ms** |
-| Shutdown + cleanup | **~19ms** |
-
-End-to-end container lifecycle (boot + disk create + hot-plug + container start):
-
-| Phase | Latency |
-|-------|---------|
-| VM boot | **~250ms** |
-| Disk image create | **~31ms** |
-| Hot-plug + CreateContainer | **~64ms** |
-| StartContainer | **~2ms** |
-| **Total** | **~350ms** |
-
-## Snapshot Restore
-
-Restore from a pre-captured golden snapshot — skips kernel boot and agent initialization.
-
-| Phase | Latency |
-|-------|---------|
-| Golden snapshot creation (one-time) | **~115ms** |
-| VM restore from snapshot | **~32ms** |
-| Network hot-add (post-restore) | **~50ms** |
-| **Total restore + networking** | **~82ms** |
-
-The golden snapshot captures a fully-booted VM with the agent running. It's created
-lazily on first use and reused for all subsequent restores. Pool warming uses snapshot
-restore when available, falling back to cold boot transparently.
+| Sandbox (VM boot) | **~97ms** |
+| Container create (disk image) | **~64ms** |
+| Container start (agent RPC) | **~160ms** |
+| Exit detection | **~100ms** |
+| **Total e2e** | **~420ms** |
 
 ## Resource Overhead (per VM)
 
 | Component | RSS |
 |-----------|-----|
 | Cloud Hypervisor (VMM) | ~50 MB |
-| Shim process | ~10 MB |
+| Shim process | ~7 MB |
 | VM guest memory | 128–512 MB (configurable) |
+| **Total host overhead** | **~57 MB** |
 
-
-process instead of a separate daemon:
-
-| Metric | Spawned | Embedded |
-|--------|---------|----------|
-| RSS per VM | ~5 MB | **0** (shared in shim) |
+No virtiofsd process — block-device-only architecture (2 processes per VM).
 
 ## Density
 
@@ -62,25 +32,23 @@ At 100 VMs per node with 128 MB guest memory:
 
 | Component | Total |
 |-----------|-------|
+| Host process overhead | ~5.7 GB |
 | Guest memory | ~12.8 GB |
-| **Total** | **~19.3 GB** |
-
-With 512 MB guest memory:
-
-| Component | Total |
-|-----------|-------|
-| Host process overhead | ~6.5 GB |
-| Guest memory | ~51.2 GB |
-| **Total** | **~57.7 GB** |
+| **Total** | **~18.5 GB** |
 
 ## Comparison
 
-| | containerd-cloudhypervisor | Kata Containers |
+Benchmarked on identical hardware (Azure D8s_v5, 3 nodes):
+
+| | containerd-cloudhypervisor | Kata Containers 3.27 |
 |---|---|---|
-| **Cold start** | ~300ms boot, ~30ms snapshot restore | ~500ms–1s |
-| **Shim binary** | 2.4 MB | ~50 MB |
-| **Agent binary** | 1.5 MB (static) | ~20 MB |
-| **Guest rootfs** | 16 MB (agent + crun only) | ~150 MB |
+| **Sandbox boot** | ~97ms | ~876ms |
+| **Total e2e** | ~420ms | ~1,134ms |
+| **VMM memory (RSS)** | ~50 MB | ~144 MB |
+| **Shim memory (RSS)** | ~7 MB | ~45 MB |
+| **Shim binary** | ~4 MB | ~65 MB |
+| **Guest rootfs** | 16 MB | ~257 MB |
+| **Total on disk** | 44 MB | 651 MB |
 | **Hypervisors** | Cloud Hypervisor only | CH, QEMU, Firecracker |
-| **TCB** | Minimal | Full Linux userspace |
+| **Architecture** | Block-device-only (no FUSE) | virtio-fs + block |
 | **Language** | Rust | Go |

--- a/example/crictl/README.md
+++ b/example/crictl/README.md
@@ -126,7 +126,6 @@ sudo tee /opt/cloudhv/config.json > /dev/null <<EOF
   "kernel_args": "console=hvc0 root=/dev/vda rw init=/init net.ifnames=0",
   "default_vcpus": 1,
   "default_memory_mb": 512,
-  "pool_size": 2,
   "max_containers_per_vm": 5,
   "tpm_enabled": false
 }


### PR DESCRIPTION
Closes #30

Updates all documentation to reflect the current architecture after PR #34
(virtiofsd removal + vsock logs).

Changes across 6 files:
- **README.md**: Updated headline performance (~420ms e2e), removed pool_size, snapshot refs
- **docs/architecture.md**: Rewrote Container Logs section (vsock RPC), replaced Volumes table (planned), removed Snapshot/Restore and embedded virtiofsd sections
- **docs/configuration.md**: Removed pool_size config
- **docs/performance.md**: Complete rewrite with real benchmark data (Kata comparison), removed snapshot restore and embedded virtiofsd sections
- **docs/README.md**: Updated index descriptions
- **example/crictl/README.md**: Removed pool_size from config example