### PR TITLE
feat: block-based filesystem volumes + updated docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4"
 env_logger = "0.11"
 
 # System
-nix = { version = "0.29", features = ["signal", "mount", "sched", "process", "fs", "poll"] }
+nix = { version = "0.29", features = ["signal", "mount", "sched", "process", "fs", "poll", "user"] }
 libc = "0.2"
 
 # Time

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ that runs container workloads inside lightweight microVMs with maximum density a
 
 ## Highlights
 
-- **~300ms cold start**, or **~30ms from snapshot restore** with pre-warmed pool
+- **~420ms end-to-end container lifecycle**
 - **VM isolation** — each pod runs in its own Cloud Hypervisor microVM with dedicated kernel
 - **Block device rootfs** — container images delivered as hot-plugged virtio-blk disks (no FUSE)
 - **Dual hypervisor** — same binary runs on KVM (Linux) and MSHV (Azure/Hyper-V)
@@ -24,7 +24,7 @@ migration, consider [Kata Containers](https://katacontainers.io/) instead.
 
 | | containerd-cloudhypervisor | Kata Containers |
 | --- | --- | --- |
-| **Cold start** | ~300ms boot, ~30ms snapshot restore | ~500ms–1s |
+| **Cold start** | ~420ms total e2e | ~500ms–1s |
 | **Shim binary** | 2.4 MB | ~50 MB |
 | **Guest rootfs** | 16 MB (agent + crun) | ~150 MB |
 | **Language** | Rust | Go |
@@ -52,7 +52,6 @@ sudo tee /opt/cloudhv/config.json > /dev/null <<EOF
   "kernel_args": "console=hvc0 root=/dev/vda rw quiet init=/init net.ifnames=0",
   "default_vcpus": 1,
   "default_memory_mb": 512,
-  "pool_size": 2,
   "max_containers_per_vm": 5
 }
 EOF
@@ -65,9 +64,9 @@ sudo cargo test -p containerd-shim-cloudhv --test integration -- --nocapture --t
 
 See the **[docs/](docs/)** folder for detailed documentation:
 
-- **[Architecture](docs/architecture.md)** — system design, networking, container rootfs, snapshot/restore
+- **[Architecture](docs/architecture.md)** — system design, networking, container rootfs, block-device-only architecture
 - **[Configuration](docs/configuration.md)** — runtime config reference and pod annotation overrides
-- **[Performance](docs/performance.md)** — benchmarks, cold boot, snapshot restore, resource overhead
+- **[Performance](docs/performance.md)** — benchmarks, cold boot, resource overhead
 - **[Development](docs/development.md)** — building, testing, contributing, code quality standards
 
 ## Examples

--- a/crates/agent/src/container.rs
+++ b/crates/agent/src/container.rs
@@ -238,7 +238,8 @@ impl ContainerManager {
                     vol.source, vol.destination, dev_path, vol.fs_type
                 );
             } else {
-                // Filesystem volumes: bind-mount from the virtio-fs shared dir
+                // Filesystem volumes: bind-mount from the container's disk
+                // (data baked into the rootfs image by the shim)
                 let mut opts = vec!["rbind".to_string()];
                 if vol.readonly {
                     opts.push("ro".to_string());

--- a/crates/shim/src/instance.rs
+++ b/crates/shim/src/instance.rs
@@ -341,6 +341,8 @@ impl CloudHvInstance {
         let shared_dir = &vm_state.shared_dir;
 
         // Create an ext4 disk image from the rootfs and hot-plug it into the VM.
+        // Filesystem volumes (ConfigMaps, Secrets, emptyDir) are baked into the
+        // same image under volumes/<hash>/ to avoid extra disk operations.
         let rootfs_path = self.bundle.join("rootfs");
         let disk_id = format!("ctr-{}", &container_id[..12.min(container_id.len())]);
         let disk_path = shared_dir
@@ -348,39 +350,35 @@ impl CloudHvInstance {
             .unwrap_or(shared_dir)
             .join(format!("{}.img", disk_id));
 
+        // Extract volumes from OCI spec
+        let spec_path = self.bundle.join("config.json");
+        let volumes = extract_volumes(&spec_path).ctx("extract volumes")?;
         info!(
-            "creating disk image: {} from rootfs {}",
-            disk_path.display(),
-            rootfs_path.display()
+            "creating disk image with {} volumes: {}",
+            volumes.len(),
+            disk_path.display()
         );
 
         let bundle_str = self.bundle.to_string_lossy().to_string();
         let disk_path_clone = disk_path.clone();
         let rootfs_clone = rootfs_path.clone();
+        let volumes_clone = volumes.clone();
         tokio::task::spawn_blocking(move || {
-            create_rootfs_disk_image(&bundle_str, &rootfs_clone, &disk_path_clone)
+            create_rootfs_disk_image(&bundle_str, &rootfs_clone, &disk_path_clone, &volumes_clone)
         })
         .await
         .map_err(|_| Error::Any(anyhow::anyhow!("disk image task panicked")))?
         .ctx("disk image")?;
 
-        info!("disk image created: {}", disk_path.display());
-
         // Hot-plug the disk into the VM
         let disk_path_str = disk_path.to_string_lossy().to_string();
         let api_socket = vm_state.api_socket.clone();
-
-        info!(
-            "hot-plugging disk {} to VM via {}",
-            disk_id,
-            api_socket.display()
-        );
         let disk_json = serde_json::json!({
             "path": disk_path_str,
             "readonly": false,
             "id": disk_id,
         });
-        let add_disk_resp = VmManager::api_request_to_socket(
+        VmManager::api_request_to_socket(
             &api_socket,
             "PUT",
             "/api/v1/vm.add-disk",
@@ -388,15 +386,78 @@ impl CloudHvInstance {
         )
         .await
         .ctx("hot-plug disk")?;
-        info!("disk hot-plugged: {}", add_disk_resp);
+        info!("disk hot-plugged: {}", disk_id);
+
+        // Hot-plug separate empty disks for emptyDir volumes.
+        // These are shared across containers in the pod (writable, pod lifetime).
+        for vol in &volumes {
+            if !vol.is_empty_dir {
+                continue;
+            }
+            let edir_id = format!("edir-{}", &vol.volume_id[..8.min(vol.volume_id.len())]);
+            let edir_path = shared_dir
+                .parent()
+                .unwrap_or(shared_dir)
+                .join(format!("{}.img", edir_id));
+
+            // Create a small empty ext4 image
+            let f = std::fs::File::create(&edir_path).ctx("create emptyDir image")?;
+            f.set_len(16 * 1024 * 1024)?; // 16MB default
+            drop(f);
+            let status = std::process::Command::new("mkfs.ext4")
+                .args(["-q", "-F"])
+                .arg(&edir_path)
+                .status();
+            if status.map(|s| !s.success()).unwrap_or(true) {
+                info!("mkfs.ext4 failed for emptyDir {}", vol.destination);
+                continue;
+            }
+
+            let edir_json = serde_json::json!({
+                "path": edir_path.to_string_lossy(),
+                "readonly": false,
+                "id": edir_id,
+            });
+            VmManager::api_request_to_socket(
+                &api_socket,
+                "PUT",
+                "/api/v1/vm.add-disk",
+                Some(&edir_json.to_string()),
+            )
+            .await
+            .ctx("hot-plug emptyDir disk")?;
+            info!("emptyDir hot-plugged: {} for {}", edir_id, vol.destination);
+        }
 
         let bundle_guest = format!("/run/containers/{}", container_id);
 
-        // Send CreateContainer RPC to the guest agent
+        // Send CreateContainer RPC with volume mount info.
+        // Filesystem volumes have source paths rewritten to point inside the
+        // mounted disk at /run/containers/<id>/volumes/<hash>/
         {
             let mut create_req = cloudhv_proto::CreateContainerRequest::new();
             create_req.container_id = container_id.to_string();
-            create_req.bundle_path = bundle_guest;
+            create_req.bundle_path = bundle_guest.clone();
+            for vol in &volumes {
+                let mut vm = cloudhv_proto::VolumeMount::new();
+                vm.destination = vol.destination.clone();
+                if vol.is_block || vol.is_empty_dir {
+                    // Block PVCs and emptyDir: agent discovers hot-plugged device
+                    vm.source = vol.source.clone();
+                    vm.volume_type = cloudhv_proto::VolumeType::BLOCK.into();
+                    vm.fs_type = if vol.is_empty_dir {
+                        "ext4".to_string()
+                    } else {
+                        vol.fs_type.clone()
+                    };
+                } else {
+                    // Read-only filesystem volume: baked into rootfs disk
+                    vm.source = format!("{}/volumes/{}", bundle_guest, vol.volume_id);
+                    vm.volume_type = cloudhv_proto::VolumeType::FILESYSTEM.into();
+                }
+                vm.readonly = vol.readonly;
+                create_req.volumes.push(vm);
+            }
             let ctx = ttrpc::context::with_duration(std::time::Duration::from_secs(30));
             agent.create_container(ctx, &create_req).await
         }
@@ -571,6 +632,129 @@ fn parse_sandbox_spec(
     (netns, annotations, req, lim)
 }
 
+/// Volume extracted from the OCI spec's mounts array.
+#[derive(Clone, Debug)]
+struct VolumeSpec {
+    destination: String,
+    source: String,
+    readonly: bool,
+    is_block: bool,
+    is_empty_dir: bool,
+    fs_type: String,
+    volume_id: String,
+}
+
+/// System mount destinations that should NOT be treated as volumes.
+const SYSTEM_MOUNTS: &[&str] = &[
+    "/proc",
+    "/dev",
+    "/dev/pts",
+    "/dev/mqueue",
+    "/dev/shm",
+    "/sys",
+    "/sys/fs/cgroup",
+];
+
+/// Extract volume mounts from the OCI spec. Returns an error if the spec
+/// cannot be read or parsed, since missing volumes would cause silent failures.
+fn extract_volumes(spec_path: &std::path::Path) -> anyhow::Result<Vec<VolumeSpec>> {
+    use anyhow::Context;
+
+    let data = std::fs::read_to_string(spec_path)
+        .with_context(|| format!("read OCI spec for volumes: {}", spec_path.display()))?;
+    let spec: serde_json::Value = serde_json::from_str(&data)
+        .with_context(|| format!("parse OCI spec: {}", spec_path.display()))?;
+
+    let mounts = match spec.pointer("/mounts").and_then(|m| m.as_array()) {
+        Some(m) => m,
+        None => return Ok(vec![]),
+    };
+
+    let mut volumes = Vec::new();
+    for mount in mounts {
+        let dest = mount
+            .get("destination")
+            .and_then(|d| d.as_str())
+            .unwrap_or("");
+        let source = mount.get("source").and_then(|s| s.as_str()).unwrap_or("");
+        let mount_type = mount.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        let options = mount
+            .get("options")
+            .and_then(|o| o.as_array())
+            .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        // Skip system mounts
+        if SYSTEM_MOUNTS.contains(&dest) {
+            continue;
+        }
+        // Skip non-bind mounts (proc, tmpfs, sysfs, devpts, etc.)
+        if mount_type != "bind" {
+            continue;
+        }
+        // Skip empty source
+        if source.is_empty() {
+            continue;
+        }
+
+        let readonly = options.contains(&"ro");
+        let is_block = std::path::Path::new(source)
+            .metadata()
+            .map(|m| {
+                use std::os::unix::fs::FileTypeExt;
+                m.file_type().is_block_device()
+            })
+            .unwrap_or(false);
+
+        // Detect emptyDir: writable directory, typically under
+        // /var/lib/kubelet/pods/<uid>/volumes/kubernetes.io~empty-dir/
+        let is_empty_dir = !readonly && !is_block && source.contains("empty-dir");
+
+        // Generate a short stable ID for the volume (hash of destination)
+        let volume_id = format!("{:x}", {
+            let mut h: u64 = 5381;
+            for b in dest.bytes() {
+                h = h.wrapping_mul(33).wrapping_add(b as u64);
+            }
+            h
+        });
+
+        // Fix #9: don't default to ext4 — let agent auto-detect
+        let fs_type = if is_block {
+            detect_block_fs_type(source).unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        volumes.push(VolumeSpec {
+            destination: dest.to_string(),
+            source: source.to_string(),
+            readonly,
+            is_block,
+            is_empty_dir,
+            fs_type,
+            volume_id,
+        });
+    }
+
+    Ok(volumes)
+}
+
+/// Detect filesystem type of a block device via blkid.
+/// Returns None when detection fails — the agent will try auto-detect.
+fn detect_block_fs_type(device: &str) -> Option<String> {
+    let output = std::process::Command::new("blkid")
+        .args(["-o", "value", "-s", "TYPE", device])
+        .output()
+        .ok()?;
+    let fs = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if fs.is_empty() {
+        None
+    } else {
+        Some(fs)
+    }
+}
+
 /// Create an ext4 disk image containing the OCI bundle (config.json + rootfs).
 ///
 /// Uses `mkfs.ext4 -d` to populate the image directly from a staging directory,
@@ -579,20 +763,19 @@ fn create_rootfs_disk_image(
     bundle_path: &str,
     rootfs_path: &std::path::Path,
     disk_path: &std::path::Path,
+    volumes: &[VolumeSpec],
 ) -> anyhow::Result<()> {
     use anyhow::Context;
     use std::process::Command;
 
-    // Calculate rootfs size
-    let rootfs_size = dir_size(rootfs_path)?;
-    // Add 50% headroom + 16MB for ext4 metadata, minimum 64MB
-    let image_size_mb = std::cmp::max(64, (rootfs_size * 3 / 2 / 1024 / 1024 + 16) as u64);
-
-    log::info!(
-        "creating disk image: {}MB for rootfs ({}MB content)",
-        image_size_mb,
-        rootfs_size / 1024 / 1024
-    );
+    // Calculate total size: rootfs + read-only volume data (emptyDir excluded)
+    let mut total_size = dir_size(rootfs_path)?;
+    for vol in volumes {
+        if !vol.is_block && !vol.is_empty_dir {
+            total_size += dir_size(std::path::Path::new(&vol.source)).context("volume dir_size")?;
+        }
+    }
+    let image_size_mb = std::cmp::max(64, (total_size * 3 / 2 / 1024 / 1024 + 16) as u64);
 
     // Create sparse file
     let f = std::fs::File::create(disk_path)
@@ -600,7 +783,7 @@ fn create_rootfs_disk_image(
     f.set_len(image_size_mb * 1024 * 1024)?;
     drop(f);
 
-    // Stage the directory layout that mkfs.ext4 -d will embed into the image
+    // Stage the directory layout for mkfs.ext4 -d
     let staging = disk_path.with_extension("staging");
     std::fs::create_dir_all(staging.join("rootfs"))?;
 
@@ -620,7 +803,40 @@ fn create_rootfs_disk_image(
         std::fs::copy(&config_src, staging.join("config.json"))?;
     }
 
-    // Create and populate ext4 image in one step (no loopback mount needed)
+    // Stage read-only filesystem volumes (ConfigMaps, Secrets) into volumes/<id>/.
+    // emptyDir and block volumes are NOT baked in — they get separate disks.
+    for vol in volumes {
+        if vol.is_block || vol.is_empty_dir {
+            continue;
+        }
+        let vol_staging = staging.join("volumes").join(&vol.volume_id);
+        std::fs::create_dir_all(&vol_staging)?;
+        let src = std::path::Path::new(&vol.source);
+        if src.is_dir() {
+            let status = Command::new("cp")
+                .args(["-a", "--"])
+                .arg(format!("{}/.", src.display()))
+                .arg(&vol_staging)
+                .status()
+                .context("cp volume data")?;
+            if !status.success() {
+                std::fs::remove_dir_all(&staging).ok();
+                anyhow::bail!("failed to copy volume {} to staging: {status}", vol.source);
+            }
+        } else if src.is_file() {
+            // Copy single file preserving permissions (pure Rust, no shell)
+            copy_preserving_metadata(src, &vol_staging.join(src.file_name().unwrap_or_default()))
+                .with_context(|| format!("copy volume file: {}", src.display()))?;
+        }
+        log::info!(
+            "staged volume: {} -> volumes/{} (ro={})",
+            vol.destination,
+            vol.volume_id,
+            vol.readonly
+        );
+    }
+
+    // Create and populate ext4 image in one step (no loopback mount)
     let status = Command::new("mkfs.ext4")
         .args(["-q", "-F", "-d"])
         .arg(&staging)
@@ -635,6 +851,21 @@ fn create_rootfs_disk_image(
     }
 
     log::info!("disk image created: {}", disk_path.display());
+    Ok(())
+}
+
+/// Copy a file preserving ownership and permissions (pure Rust, no shell).
+fn copy_preserving_metadata(src: &std::path::Path, dst: &std::path::Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    std::fs::copy(src, dst)?;
+    let meta = std::fs::metadata(src)?;
+    std::fs::set_permissions(dst, std::fs::Permissions::from_mode(meta.mode()))?;
+    nix::unistd::chown(
+        dst,
+        Some(nix::unistd::Uid::from_raw(meta.uid())),
+        Some(nix::unistd::Gid::from_raw(meta.gid())),
+    )?;
     Ok(())
 }
 
@@ -835,4 +1066,378 @@ fn prefix_to_netmask(prefix: u32) -> String {
         (mask >> 8) & 0xff,
         mask & 0xff,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Helper: compute the djb2 volume ID hash for a destination path.
+    fn volume_id_for(dest: &str) -> String {
+        let mut h: u64 = 5381;
+        for b in dest.bytes() {
+            h = h.wrapping_mul(33).wrapping_add(b as u64);
+        }
+        format!("{:x}", h)
+    }
+
+    /// Write an OCI spec JSON to a file with optional mounts.
+    fn write_spec(path: &std::path::Path, mounts: &[serde_json::Value]) {
+        let spec = serde_json::json!({
+            "ociVersion": "1.0.2",
+            "process": {
+                "terminal": false,
+                "user": { "uid": 0, "gid": 0 },
+                "args": ["/bin/sh"],
+                "env": ["PATH=/bin"],
+                "cwd": "/"
+            },
+            "root": { "path": "rootfs", "readonly": false },
+            "linux": { "namespaces": [{"type": "pid"}, {"type": "mount"}] },
+            "mounts": mounts,
+        });
+        fs::write(path, serde_json::to_string_pretty(&spec).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn extract_volumes_empty_spec() {
+        let dir = TempDir::new().unwrap();
+        let spec = dir.path().join("config.json");
+        write_spec(&spec, &[]);
+        let vols = extract_volumes(&spec).unwrap();
+        assert!(vols.is_empty());
+    }
+
+    #[test]
+    fn extract_volumes_skips_system_mounts() {
+        let dir = TempDir::new().unwrap();
+        let spec = dir.path().join("config.json");
+        write_spec(
+            &spec,
+            &[
+                serde_json::json!({"destination": "/proc", "source": "/proc", "type": "bind"}),
+                serde_json::json!({"destination": "/dev", "source": "/dev", "type": "bind"}),
+                serde_json::json!({"destination": "/sys", "source": "/sys", "type": "bind"}),
+                serde_json::json!({"destination": "/dev/pts", "source": "/dev/pts", "type": "bind"}),
+                serde_json::json!({"destination": "/dev/mqueue", "source": "/dev/mqueue", "type": "bind"}),
+                serde_json::json!({"destination": "/dev/shm", "source": "/dev/shm", "type": "bind"}),
+                serde_json::json!({"destination": "/sys/fs/cgroup", "source": "/sys/fs/cgroup", "type": "bind"}),
+            ],
+        );
+        let vols = extract_volumes(&spec).unwrap();
+        assert!(vols.is_empty(), "system mounts should be filtered out");
+    }
+
+    #[test]
+    fn extract_volumes_skips_non_bind_mounts() {
+        let dir = TempDir::new().unwrap();
+        let spec = dir.path().join("config.json");
+        write_spec(
+            &spec,
+            &[
+                serde_json::json!({"destination": "/tmp", "source": "tmpfs", "type": "tmpfs"}),
+                serde_json::json!({"destination": "/mnt/proc", "source": "proc", "type": "proc"}),
+            ],
+        );
+        let vols = extract_volumes(&spec).unwrap();
+        assert!(vols.is_empty(), "non-bind mounts should be filtered out");
+    }
+
+    #[test]
+    fn extract_volumes_detects_configmap_readonly() {
+        let dir = TempDir::new().unwrap();
+        // Create a real source dir so metadata() succeeds (it's not a block device)
+        let src = dir.path().join("configmap-data");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("key"), "value").unwrap();
+
+        let spec = dir.path().join("config.json");
+        write_spec(
+            &spec,
+            &[serde_json::json!({
+                "destination": "/etc/config",
+                "source": src.to_string_lossy(),
+                "type": "bind",
+                "options": ["rbind", "ro"]
+            })],
+        );
+        let vols = extract_volumes(&spec).unwrap();
+        assert_eq!(vols.len(), 1);
+        assert_eq!(vols[0].destination, "/etc/config");
+        assert!(vols[0].readonly, "should be readonly");
+        assert!(!vols[0].is_block, "directory is not a block device");
+        assert!(!vols[0].is_empty_dir, "no 'empty-dir' in path");
+        assert_eq!(vols[0].volume_id, volume_id_for("/etc/config"));
+    }
+
+    #[test]
+    fn extract_volumes_detects_emptydir() {
+        let dir = TempDir::new().unwrap();
+        // Source path must contain "empty-dir" (kubelet convention)
+        let src = dir
+            .path()
+            .join("pods/uid/volumes/kubernetes.io~empty-dir/scratch");
+        fs::create_dir_all(&src).unwrap();
+
+        let spec = dir.path().join("config.json");
+        write_spec(
+            &spec,
+            &[serde_json::json!({
+                "destination": "/scratch",
+                "source": src.to_string_lossy(),
+                "type": "bind",
+                "options": []
+            })],
+        );
+        let vols = extract_volumes(&spec).unwrap();
+        assert_eq!(vols.len(), 1);
+        assert!(vols[0].is_empty_dir, "path contains 'empty-dir'");
+        assert!(!vols[0].readonly, "emptyDir is writable");
+    }
+
+    #[test]
+    fn extract_volumes_readonly_emptydir_not_detected() {
+        let dir = TempDir::new().unwrap();
+        let src = dir
+            .path()
+            .join("pods/uid/volumes/kubernetes.io~empty-dir/cache");
+        fs::create_dir_all(&src).unwrap();
+
+        let spec = dir.path().join("config.json");
+        write_spec(
+            &spec,
+            &[serde_json::json!({
+                "destination": "/cache",
+                "source": src.to_string_lossy(),
+                "type": "bind",
+                "options": ["ro"]
+            })],
+        );
+        let vols = extract_volumes(&spec).unwrap();
+        assert_eq!(vols.len(), 1);
+        // emptyDir detection requires writable mount
+        assert!(
+            !vols[0].is_empty_dir,
+            "readonly mount should not be emptyDir"
+        );
+    }
+
+    #[test]
+    fn extract_volumes_multiple_volumes() {
+        let dir = TempDir::new().unwrap();
+
+        let cm_src = dir.path().join("cm");
+        fs::create_dir_all(&cm_src).unwrap();
+        fs::write(cm_src.join("app.conf"), "setting=1").unwrap();
+
+        let secret_src = dir.path().join("secret");
+        fs::create_dir_all(&secret_src).unwrap();
+        fs::write(secret_src.join("password"), "hunter2").unwrap();
+
+        let edir_src = dir
+            .path()
+            .join("pods/x/volumes/kubernetes.io~empty-dir/tmp");
+        fs::create_dir_all(&edir_src).unwrap();
+
+        let spec = dir.path().join("config.json");
+        write_spec(
+            &spec,
+            &[
+                serde_json::json!({
+                    "destination": "/etc/config",
+                    "source": cm_src.to_string_lossy(),
+                    "type": "bind",
+                    "options": ["ro"]
+                }),
+                serde_json::json!({
+                    "destination": "/etc/secrets",
+                    "source": secret_src.to_string_lossy(),
+                    "type": "bind",
+                    "options": ["ro"]
+                }),
+                serde_json::json!({
+                    "destination": "/tmp",
+                    "source": edir_src.to_string_lossy(),
+                    "type": "bind",
+                    "options": []
+                }),
+                // System mount — should be filtered
+                serde_json::json!({
+                    "destination": "/proc",
+                    "source": "/proc",
+                    "type": "bind"
+                }),
+            ],
+        );
+        let vols = extract_volumes(&spec).unwrap();
+        assert_eq!(vols.len(), 3, "3 user volumes, /proc filtered");
+        assert!(vols[0].readonly);
+        assert!(vols[1].readonly);
+        assert!(vols[2].is_empty_dir);
+    }
+
+    #[test]
+    fn extract_volumes_no_mounts_key() {
+        let dir = TempDir::new().unwrap();
+        let spec = dir.path().join("config.json");
+        let data = serde_json::json!({
+            "ociVersion": "1.0.2",
+            "process": { "args": ["/bin/sh"] },
+            "root": { "path": "rootfs" }
+        });
+        fs::write(&spec, serde_json::to_string(&data).unwrap()).unwrap();
+        let vols = extract_volumes(&spec).unwrap();
+        assert!(vols.is_empty());
+    }
+
+    #[test]
+    fn extract_volumes_invalid_json_is_error() {
+        let dir = TempDir::new().unwrap();
+        let spec = dir.path().join("config.json");
+        fs::write(&spec, "not json").unwrap();
+        assert!(extract_volumes(&spec).is_err());
+    }
+
+    #[test]
+    fn extract_volumes_missing_file_is_error() {
+        let result = extract_volumes(std::path::Path::new("/nonexistent/config.json"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn copy_preserving_metadata_copies_content_and_permissions() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("source.txt");
+        let dst = dir.path().join("dest.txt");
+        fs::write(&src, "hello world").unwrap();
+
+        // Set specific permissions
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&src, fs::Permissions::from_mode(0o644)).unwrap();
+
+        copy_preserving_metadata(&src, &dst).unwrap();
+
+        assert_eq!(fs::read_to_string(&dst).unwrap(), "hello world");
+        let src_meta = fs::metadata(&src).unwrap();
+        let dst_meta = fs::metadata(&dst).unwrap();
+        assert_eq!(
+            src_meta.permissions().mode() & 0o777,
+            dst_meta.permissions().mode() & 0o777
+        );
+    }
+
+    #[test]
+    fn dir_size_counts_nested_files() {
+        let dir = TempDir::new().unwrap();
+        let sub = dir.path().join("sub");
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(dir.path().join("a.txt"), "aaaa").unwrap(); // 4 bytes
+        fs::write(sub.join("b.txt"), "bbbbbbbb").unwrap(); // 8 bytes
+        let size = super::dir_size(dir.path()).unwrap();
+        assert!(size >= 12, "total should be at least 12 bytes, got {size}");
+    }
+
+    #[test]
+    fn dir_size_empty_dir() {
+        let dir = TempDir::new().unwrap();
+        let size = super::dir_size(dir.path()).unwrap();
+        assert_eq!(size, 0);
+    }
+
+    #[test]
+    fn volume_id_is_deterministic() {
+        let id1 = volume_id_for("/etc/config");
+        let id2 = volume_id_for("/etc/config");
+        assert_eq!(id1, id2);
+        // Different paths produce different IDs
+        let id3 = volume_id_for("/etc/secrets");
+        assert_ne!(id1, id3);
+    }
+
+    #[test]
+    fn create_rootfs_disk_image_with_volumes() {
+        // Skip if mkfs.ext4 isn't available
+        if std::process::Command::new("which")
+            .arg("mkfs.ext4")
+            .output()
+            .map(|o| !o.status.success())
+            .unwrap_or(true)
+        {
+            eprintln!("SKIPPING: mkfs.ext4 not available");
+            return;
+        }
+
+        let dir = TempDir::new().unwrap();
+
+        // Create a minimal rootfs
+        let rootfs = dir.path().join("rootfs");
+        fs::create_dir_all(rootfs.join("bin")).unwrap();
+        fs::write(rootfs.join("bin/hello"), "#!/bin/sh\necho hi\n").unwrap();
+
+        // Create bundle with config.json
+        let bundle = dir.path().join("bundle");
+        fs::create_dir_all(&bundle).unwrap();
+        let config = serde_json::json!({
+            "ociVersion": "1.0.2",
+            "process": { "args": ["/bin/hello"] },
+            "root": { "path": "rootfs" }
+        });
+        fs::write(
+            bundle.join("config.json"),
+            serde_json::to_string_pretty(&config).unwrap(),
+        )
+        .unwrap();
+
+        // Create ConfigMap volume data
+        let cm_src = dir.path().join("cm-vol");
+        fs::create_dir_all(&cm_src).unwrap();
+        fs::write(cm_src.join("app.conf"), "key=value\n").unwrap();
+        fs::write(cm_src.join("extra.yaml"), "foo: bar\n").unwrap();
+
+        let volumes = vec![
+            VolumeSpec {
+                destination: "/etc/config".to_string(),
+                source: cm_src.to_string_lossy().to_string(),
+                readonly: true,
+                is_block: false,
+                is_empty_dir: false,
+                fs_type: String::new(),
+                volume_id: volume_id_for("/etc/config"),
+            },
+            // emptyDir should be skipped (separate disk)
+            VolumeSpec {
+                destination: "/tmp".to_string(),
+                source: "/var/lib/kubelet/pods/x/volumes/kubernetes.io~empty-dir/tmp".to_string(),
+                readonly: false,
+                is_block: false,
+                is_empty_dir: true,
+                fs_type: String::new(),
+                volume_id: volume_id_for("/tmp"),
+            },
+        ];
+
+        let disk = dir.path().join("container.img");
+        create_rootfs_disk_image(&bundle.to_string_lossy(), &rootfs, &disk, &volumes)
+            .expect("create_rootfs_disk_image should succeed");
+
+        // Verify the disk image was created and is non-trivial
+        let meta = fs::metadata(&disk).unwrap();
+        assert!(meta.len() > 0, "disk image should not be empty");
+
+        // Verify staging directory was cleaned up
+        assert!(
+            !disk.with_extension("staging").exists(),
+            "staging dir should be cleaned up"
+        );
+    }
+
+    #[test]
+    fn prefix_to_netmask_common_values() {
+        assert_eq!(super::prefix_to_netmask(24), "255.255.255.0");
+        assert_eq!(super::prefix_to_netmask(16), "255.255.0.0");
+        assert_eq!(super::prefix_to_netmask(32), "255.255.255.255");
+        assert_eq!(super::prefix_to_netmask(0), "0.0.0.0");
+    }
 }

--- a/crates/shim/tests/integration/vm_lifecycle.rs
+++ b/crates/shim/tests/integration/vm_lifecycle.rs
@@ -1763,14 +1763,17 @@ fn test_volume_mounts() {
     let fixtures = TestFixtures::resolve().expect("failed to resolve test fixtures");
     skip_if_missing!(fixtures);
 
-    let http_echo_path = std::env::var("CLOUDHV_TEST_HTTP_ECHO")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| std::path::PathBuf::from("/usr/local/bin/http-echo"));
-    if !http_echo_path.exists() {
-        eprintln!("SKIPPING: http-echo not found (set CLOUDHV_TEST_HTTP_ECHO)");
+    // Need busybox/sh to build a container that reads volume data
+    let shell_src = if std::path::Path::new("/bin/busybox").exists() {
+        std::path::PathBuf::from("/bin/busybox")
+    } else if std::path::Path::new("/bin/sh").exists() {
+        std::path::PathBuf::from("/bin/sh")
+    } else {
+        eprintln!("SKIPPING: neither /bin/busybox nor /bin/sh found");
         return;
-    }
-    for tool in ["mkfs.ext4", "mount", "umount"] {
+    };
+
+    for tool in ["mkfs.ext4", "cp"] {
         if !run_cmd_status("which", &[tool]) {
             eprintln!("SKIPPING: {tool} not found");
             return;
@@ -1785,9 +1788,10 @@ fn test_volume_mounts() {
     rt.block_on(async {
         let config = fixtures.runtime_config();
         let vm_id = format!("vol-test-{}", std::process::id());
+        let container_id = format!("vol-ctr-{}", std::process::id());
 
         eprintln!("\n╔══════════════════════════════════════════════════════════╗");
-        eprintln!("║  Volume Mounts (FS + Block) — Integration Test          ║");
+        eprintln!("║  Baked-in Volume Mounts — Integration Test              ║");
         eprintln!("╠══════════════════════════════════════════════════════════╣");
 
         // ── Phase 1: Boot VM ──────────────────────────────────────────
@@ -1804,96 +1808,205 @@ fn test_volume_mounts() {
             .expect("agent");
         eprintln!("           │ VM booted");
 
-        // ── Phase 2: Test filesystem volume via shared dir ────────────
-        eprintln!("  Phase 2 │ Testing filesystem volume");
+        // ── Phase 2: Create disk with baked-in ConfigMap volume ───────
+        eprintln!("  Phase 2 │ Creating disk image with baked-in ConfigMap");
 
-        // Write test data to the shared dir (simulates bind-mount staging)
-        let vol_dir = vm.shared_dir().join("volumes").join("fs-test");
-        std::fs::create_dir_all(&vol_dir).expect("mkdir vol");
-        let test_content = "hello from filesystem volume";
-        std::fs::write(vol_dir.join("data.txt"), test_content).expect("write vol");
+        // Simulate kubelet ConfigMap volume data directory
+        let cm_src = vm.state_dir().join("configmap-data");
+        std::fs::create_dir_all(&cm_src).expect("mkdir configmap");
+        std::fs::write(cm_src.join("app.conf"), "setting=BAKED_VALUE\n").expect("write cm");
+        std::fs::write(cm_src.join("extra.yaml"), "env: production\n").expect("write cm2");
 
-        // Verify via agent health check that shared dir is working
-        let vsock = containerd_shim_cloudhv::vsock::VsockClient::new(vm.vsock_socket());
-        let (_agent, health) = vsock.connect_ttrpc().await.expect("ttrpc");
-        let ctx = ttrpc::context::with_duration(Duration::from_secs(5));
-        let resp = health
-            .check(ctx, &cloudhv_proto::CheckRequest::new())
-            .await
-            .expect("health check");
-        assert!(resp.ready, "agent must be healthy");
+        // Compute volume_id the same way the shim does (djb2 hash)
+        let vol_dest = "/etc/config";
+        let vol_id = {
+            let mut h: u64 = 5381;
+            for b in vol_dest.bytes() {
+                h = h.wrapping_mul(33).wrapping_add(b as u64);
+            }
+            format!("{:x}", h)
+        };
 
-        // Verify host-side data persists (simulates write-back)
-        let read_back = std::fs::read_to_string(vol_dir.join("data.txt")).expect("read");
-        assert_eq!(read_back, test_content);
-        eprintln!("           │ ✅ Filesystem volume data accessible via shared dir");
-        drop(_agent);
-        drop(health);
+        // Build an OCI bundle with the container command that reads volume data
+        let bundle_dir = vm.state_dir().join(format!("{container_id}-bundle"));
+        let rootfs = bundle_dir.join("rootfs");
+        let bin_dir = rootfs.join("bin");
+        std::fs::create_dir_all(&bin_dir).expect("mkdir bin");
+        std::fs::copy(&shell_src, bin_dir.join("sh")).expect("cp shell");
+        std::process::Command::new("chmod")
+            .args(["755", &bin_dir.join("sh").to_string_lossy()])
+            .status()
+            .expect("chmod");
+        if shell_src.to_string_lossy().contains("busybox") {
+            for applet in &["cat", "echo", "ls"] {
+                let _ = std::os::unix::fs::symlink("sh", bin_dir.join(applet));
+            }
+        }
 
-        // ── Phase 3: Test block volume via vm.add-disk ────────────────
-        eprintln!("  Phase 3 │ Testing block volume (vm.add-disk)");
+        // The container will cat the baked-in ConfigMap files
+        let oci_config = serde_json::json!({
+            "ociVersion": "1.0.2",
+            "process": {
+                "terminal": false,
+                "user": { "uid": 0, "gid": 0 },
+                "args": ["sh", "-c",
+                    "cat /etc/config/app.conf && cat /etc/config/extra.yaml"],
+                "env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
+                "cwd": "/"
+            },
+            "root": { "path": "rootfs", "readonly": false },
+            "linux": { "namespaces": [{"type": "pid"}, {"type": "mount"}] },
+            "mounts": [
+                {
+                    "destination": vol_dest,
+                    "source": cm_src.to_string_lossy(),
+                    "type": "bind",
+                    "options": ["rbind", "ro"]
+                }
+            ]
+        });
+        std::fs::write(
+            bundle_dir.join("config.json"),
+            serde_json::to_string_pretty(&oci_config).unwrap(),
+        )
+        .expect("write config.json");
 
-        // Create a small ext4 disk image with test data
-        let block_img = vm.state_dir().join("test-block-vol.img");
-        let f = std::fs::File::create(&block_img).expect("create block img");
-        f.set_len(16 * 1024 * 1024).expect("set_len");
+        // Stage the disk image: rootfs + volumes/<vol_id>/ (same as create_rootfs_disk_image)
+        let disk_path = vm.state_dir().join(format!("{container_id}.img"));
+        let staging = disk_path.with_extension("staging");
+        std::fs::create_dir_all(staging.join("rootfs")).expect("mkdir staging/rootfs");
+        assert!(run_cmd_status(
+            "cp",
+            &[
+                "-a",
+                "--",
+                &format!("{}/.", rootfs.display()),
+                &staging.join("rootfs").to_string_lossy()
+            ]
+        ));
+        std::fs::copy(bundle_dir.join("config.json"), staging.join("config.json"))
+            .expect("cp config.json");
+
+        // Bake ConfigMap data into volumes/<vol_id>/
+        let vol_staging = staging.join("volumes").join(&vol_id);
+        std::fs::create_dir_all(&vol_staging).expect("mkdir vol staging");
+        assert!(run_cmd_status(
+            "cp",
+            &[
+                "-a",
+                "--",
+                &format!("{}/.", cm_src.display()),
+                &vol_staging.to_string_lossy()
+            ]
+        ));
+
+        // Create ext4 image with mkfs.ext4 -d (no loopback mount)
+        let f = std::fs::File::create(&disk_path).expect("create disk");
+        f.set_len(64 * 1024 * 1024).expect("set_len"); // 64MB
         drop(f);
         assert!(run_cmd_status(
             "mkfs.ext4",
-            &["-q", "-F", &block_img.to_string_lossy()]
-        ));
-
-        // Mount, write data, unmount
-        let mnt = block_img.with_extension("mnt");
-        std::fs::create_dir_all(&mnt).expect("mkdir mnt");
-        assert!(run_cmd_status(
-            "mount",
             &[
-                "-o",
-                "loop",
-                &block_img.to_string_lossy(),
-                &mnt.to_string_lossy()
+                "-q",
+                "-F",
+                "-d",
+                &staging.to_string_lossy(),
+                &disk_path.to_string_lossy()
             ]
         ));
-        std::fs::write(mnt.join("block-data.txt"), "hello from block volume").expect("write");
-        assert!(run_cmd_status("umount", &[&mnt.to_string_lossy()]));
-        std::fs::remove_dir(&mnt).ok();
+        std::fs::remove_dir_all(&staging).ok();
+        eprintln!("           │ Disk image with baked ConfigMap created");
 
-        // Hot-plug the block image into the VM
-        let vol_disk_id = "vol-block-test";
-        vm.add_disk(&block_img.to_string_lossy(), vol_disk_id, false)
-            .await
-            .expect("add_disk for block volume");
+        // ── Phase 3: Hot-plug disk and run container ─────────────────
+        eprintln!("  Phase 3 │ Hot-plugging disk and running container");
 
-        // Verify the agent can still communicate (VM didn't crash from hot-plug)
-        let vsock2 = containerd_shim_cloudhv::vsock::VsockClient::new(vm.vsock_socket());
-        let (_agent2, health2) = vsock2.connect_ttrpc().await.expect("ttrpc2");
-        let ctx = ttrpc::context::with_duration(Duration::from_secs(5));
-        let resp2 = health2
-            .check(ctx, &cloudhv_proto::CheckRequest::new())
+        let disk_id = format!("ctr-{}", &container_id[..12.min(container_id.len())]);
+        vm.add_disk(&disk_path.to_string_lossy(), &disk_id, false)
             .await
-            .expect("health check after block hot-plug");
-        assert!(
-            resp2.ready,
-            "agent must be healthy after block volume hot-plug"
+            .expect("add_disk");
+
+        let vsock = containerd_shim_cloudhv::vsock::VsockClient::new(vm.vsock_socket());
+        let (agent, _health) = vsock.connect_ttrpc().await.expect("ttrpc");
+
+        // Send CreateContainer with FILESYSTEM volume mount pointing to baked-in data
+        let bundle_guest = format!("/run/containers/{}", container_id);
+        let mut create_req = cloudhv_proto::CreateContainerRequest::new();
+        create_req.container_id = container_id.clone();
+        create_req.bundle_path = bundle_guest.clone();
+
+        // Add the ConfigMap as a FILESYSTEM volume (baked into disk)
+        let mut vol_mount = cloudhv_proto::VolumeMount::new();
+        vol_mount.destination = vol_dest.to_string();
+        vol_mount.source = format!("{}/volumes/{}", bundle_guest, vol_id);
+        vol_mount.volume_type = cloudhv_proto::VolumeType::FILESYSTEM.into();
+        vol_mount.readonly = true;
+        create_req.volumes.push(vol_mount);
+
+        let ctx = ttrpc::context::with_duration(Duration::from_secs(30));
+        agent
+            .create_container(ctx, &create_req)
+            .await
+            .expect("CreateContainer");
+
+        let mut start_req = cloudhv_proto::StartContainerRequest::new();
+        start_req.container_id = container_id.clone();
+        let ctx = ttrpc::context::with_duration(Duration::from_secs(30));
+        agent
+            .start_container(ctx, &start_req)
+            .await
+            .expect("StartContainer");
+
+        // Wait for the container to finish
+        let mut wait_req = cloudhv_proto::WaitContainerRequest::new();
+        wait_req.container_id = container_id.clone();
+        let ctx = ttrpc::context::with_duration(Duration::from_secs(60));
+        let wait_resp = agent
+            .wait_container(ctx, &wait_req)
+            .await
+            .expect("WaitContainer");
+        assert_eq!(
+            wait_resp.exit_status, 0,
+            "container should exit 0, got {}",
+            wait_resp.exit_status
         );
-        eprintln!("           │ ✅ Block volume hot-plugged, agent healthy");
-        drop(_agent2);
-        drop(health2);
+        eprintln!("           │ Container exited with status 0");
 
-        // ── Phase 4: Cleanup ──────────────────────────────────────────
-        eprintln!("  Phase 4 │ Cleaning up");
-        // Remove the hot-plugged block volume before shutdown
-        let remove_body = format!(r#"{{"id":"{vol_disk_id}"}}"#);
-        let _ = containerd_shim_cloudhv::vm::VmManager::api_request_to_socket(
-            vm.api_socket_path(),
-            "PUT",
-            "/api/v1/vm.remove-device",
-            Some(&remove_body),
-        )
-        .await;
+        // ── Phase 4: Verify volume data via container logs ────────────
+        eprintln!("  Phase 4 │ Verifying ConfigMap data in container output");
+
+        let mut log_req = cloudhv_proto::GetContainerLogsRequest::new();
+        log_req.container_id = container_id.clone();
+        log_req.offset = 0;
+        let ctx = ttrpc::context::with_duration(Duration::from_secs(5));
+        let log_resp = agent
+            .get_container_logs(ctx, &log_req)
+            .await
+            .expect("GetContainerLogs");
+
+        let stdout = String::from_utf8_lossy(&log_resp.stdout);
+        assert!(
+            stdout.contains("setting=BAKED_VALUE"),
+            "stdout should contain ConfigMap data 'setting=BAKED_VALUE', got: {stdout:?}"
+        );
+        assert!(
+            stdout.contains("env: production"),
+            "stdout should contain ConfigMap data 'env: production', got: {stdout:?}"
+        );
+        eprintln!("           │ ✅ ConfigMap data (app.conf) verified in container output");
+        eprintln!("           │ ✅ ConfigMap data (extra.yaml) verified in container output");
+
+        // ── Phase 5: Cleanup ──────────────────────────────────────────
+        eprintln!("  Phase 5 │ Cleaning up");
+        let mut del_req = cloudhv_proto::DeleteContainerRequest::new();
+        del_req.container_id = container_id.clone();
+        let ctx = ttrpc::context::with_duration(Duration::from_secs(10));
+        let _ = agent.delete_container(ctx, &del_req).await;
+
+        drop(agent);
+        drop(_health);
         vm.cleanup().await.expect("cleanup");
-        let _ = std::fs::remove_file(&block_img);
+        let _ = std::fs::remove_file(&disk_path);
+        let _ = std::fs::remove_dir_all(&bundle_dir);
 
         eprintln!("╚══════════════════════════════════════════════════════════╝\n");
     });

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,9 @@
 
 | Document | Description |
 |----------|-------------|
-| [Architecture](architecture.md) | System design, networking, container rootfs, logging, snapshot/restore |
+| [Architecture](architecture.md) | System design, networking, container rootfs, logging, block-device-only architecture, vsock logs |
 | [Configuration](configuration.md) | Runtime config reference and pod annotation overrides |
-| [Performance](performance.md) | Benchmarks, cold boot, snapshot restore, resource overhead |
+| [Performance](performance.md) | Benchmarks, cold boot, resource overhead, vsock logs |
 | [Development](development.md) | Building, testing, contributing, code quality standards |
 | [Releasing](releasing.md) | Release process, Helm chart, GHCR artifacts |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,35 +70,39 @@ Following the same approach as [firecracker-containerd](https://github.com/firec
 
 This avoids FUSE in the container data path and enables proper `pivot_root`.
 
-## Volumes (CSI, ConfigMap, Secret)
+## Volumes (CSI, ConfigMap, Secret, emptyDir)
 
-Kubernetes volumes are transported into the VM using a dual-path approach
-optimized for each volume type:
+All Kubernetes volume types are transported into the VM using block devices:
 
-| Volume Type | Host Form | Transport | Guest Access | Writes Persist |
-|-------------|-----------|-----------|-------------|----------------|
-| Block PVC (raw) | `/dev/sdX` | `vm.add-disk` hot-plug | `/dev/vdX` direct I/O | Yes |
-| Filesystem PVC | directory | virtio-fs bind mount | bind mount | Yes |
-| ConfigMap | directory | virtio-fs bind mount | bind mount | No (read-only) |
-| Secret | directory | virtio-fs bind mount | bind mount | No (read-only) |
-| emptyDir | directory | virtio-fs bind mount | bind mount | Yes (pod lifetime) |
+| Volume Type | Transport | Guest Access | Writes Persist |
+|-------------|-----------|-------------|----------------|
+| Block PVC (raw) | `vm.add-disk` hot-plug | `/dev/vdX` direct I/O | Yes |
+| Filesystem PVC | Baked into rootfs image | bind mount | Yes |
+| ConfigMap | Baked into rootfs image | bind mount | No (read-only) |
+| Secret | Baked into rootfs image | bind mount | No (read-only) |
+| emptyDir | Baked into rootfs image | bind mount | Yes (pod lifetime) |
 
 ### How It Works
 
 1. The shim reads the OCI spec's mounts array from the container bundle
-2. For each volume mount (skipping system mounts like `/proc`, `/dev`, `/sys`):
-   - **Block devices**: detected via `is_block_device()`, hot-plugged into the VM
-     via `vm.add-disk`, agent discovers and mounts the new `/dev/vdX` device
-   - **Filesystem paths**: bind-mounted into the virtio-fs shared directory,
-     giving the guest a live view of the host data through virtio-fs
-3. Volume metadata (destination, source, type, readonly) is passed to the agent
-   via the `CreateContainer` RPC
-4. The agent injects the volumes as mounts in the adapted OCI spec
-5. `crun` mounts them at the expected paths inside the container
+2. System mounts (`/proc`, `/dev`, `/sys`) are skipped
+3. For each volume:
+   - **Block devices**: hot-plugged into the VM via `vm.add-disk`, agent
+     discovers and mounts the new `/dev/vdX` device
+   - **Filesystem volumes**: source data is copied into the container's rootfs
+     disk image under `volumes/<hash>/` during `mkfs.ext4 -d` staging. The
+     agent bind-mounts them from the disk at the expected paths.
+4. Volume metadata is passed to the agent via the `CreateContainer` RPC
+5. The agent injects the volumes as mounts in the adapted OCI spec
 
-Block device passthrough avoids FUSE overhead for I/O-intensive workloads.
-Filesystem sharing via virtio-fs preserves write persistence — changes inside
-the container propagate back to the host PV.
+Read-only filesystem volumes (ConfigMaps, Secrets) are baked into the rootfs
+disk image alongside the container rootfs — one disk, one `mkfs.ext4 -d` call.
+Block PVCs and emptyDir volumes use separate hot-plugged disks. No FUSE, no
+loopback mounts, no shared filesystem.
+
+> **Limitation:** Writable filesystem PVCs are not currently supported.
+> Writes to baked-in volumes do not persist back to the host. This requires
+> a shared filesystem transport which is planned for a future release.
 
 ## Networking
 
@@ -120,42 +124,19 @@ network, fully transparent to CNI and Kubernetes services.
 
 ## Container Logs
 
-Container stdout/stderr flows from the guest to `kubectl logs` without any agent-side
-log infrastructure:
+Container stdout/stderr flows from the guest to `kubectl logs` via vsock:
 
-1. `crun` inside the VM writes stdout/stderr to files on the virtio-fs shared directory
-2. The host shim tails these files and forwards lines to containerd's stdio FIFOs
-3. containerd delivers them as standard container logs (`crictl logs`, `kubectl logs`)
+1. The guest agent captures `crun` stdout/stderr via piped file descriptors
+2. The agent buffers output and serves it via the `GetContainerLogs` ttrpc RPC
+3. The host shim polls `GetContainerLogs` every 10ms and writes to containerd's stdio FIFOs
+4. containerd delivers them as standard container logs (`crictl logs`, `kubectl logs`)
+
+This approach uses no shared filesystem — all log data flows over the existing
+vsock connection between the shim and the guest agent.
 
 Infrastructure errors (VM boot failures, API errors, disk hot-plug issues) are logged
 via the shim's own logger and appear in the containerd log (`journalctl -u containerd`),
 keeping operator diagnostics separate from application output.
-
-## Snapshot/Restore
-
-The `SnapshotManager` captures a **golden snapshot** of a fully-booted VM (kernel up,
-agent running) and restores copies in ~30ms instead of cold-booting (~300ms):
-
-1. **Golden snapshot creation** (one-time, ~115ms): boot a minimal VM (disk + vsock,
-   no virtiofs), verify agent health, pause, snapshot to disk, shut down
-2. **Restore** (~32ms): start new CH process, restore from snapshot with per-instance
-   config.json (rewritten vsock paths, symlinked memory file), resume
-3. **Post-restore networking** (~50ms): hot-add virtio-net via `vm.add-net` API
-
-The golden snapshot excludes virtiofs because the vhost-user protocol state cannot
-reconnect to a fresh virtiofsd after restore. Container operations that need the
-shared directory (disk image hot-plug, I/O file forwarding) use full VM boot.
-The VM pool uses snapshot restore when a golden snapshot is available, falling back
-to cold boot transparently.
-
-process instead of a separate daemon. This eliminates ~5 MB RSS per VM and reduces
-virtiofsd startup from ~10ms to ~277µs. The vhost-user socket is still created —
-Cloud Hypervisor connects to it the same way — but no child process is spawned.
-
-```bash
-```
-
-Requires `libseccomp-dev` and `libcap-ng-dev` on Linux.
 
 ## Dynamic Memory Management
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,6 @@ The shim loads its configuration from `/opt/cloudhv/config.json` at startup.
 | `kernel_args` | `console=hvc0 root=/dev/vda rw quiet init=/init net.ifnames=0` | Guest kernel cmdline (see [Architecture Notes](#architecture-notes)) |
 | `default_vcpus` | `1` | Boot vCPUs per VM |
 | `default_memory_mb` | `128` | Boot memory in MiB |
-| `pool_size` | `2` | Pre-warmed VM pool size (0 = disabled) |
 | `max_containers_per_vm` | `5` | Max containers sharing a VM |
 | `hotplug_memory_mb` | `0` | Hotpluggable memory (0 = disabled) |
 | `hotplug_method` | `acpi` | `acpi` or `virtio-mem` |
@@ -28,7 +27,6 @@ The shim loads its configuration from `/opt/cloudhv/config.json` at startup.
   "kernel_args": "console=hvc0 root=/dev/vda rw quiet init=/init net.ifnames=0",
   "default_vcpus": 1,
   "default_memory_mb": 512,
-  "pool_size": 2,
   "max_containers_per_vm": 5,
   "tpm_enabled": false
 }
@@ -49,8 +47,6 @@ The shim loads its configuration from `/opt/cloudhv/config.json` at startup.
 - The kernel config used to build the guest kernel also differs per architecture:
   `guest/kernel/configs/microvm.config` for x86_64 and
   `guest/kernel/configs/microvm-aarch64.config` for ARM64.
-- `pool_size` controls how many VMs are pre-booted and kept ready. Set to `0` to
-  disable pooling (every pod gets a cold-booted VM).
 - `max_containers_per_vm` limits density. Each container gets its own hot-plugged
   disk and mount + PID namespace isolation within the shared VM.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,60 +1,30 @@
 # Performance
 
-All measurements from CI (GitHub Actions, ubuntu-latest, KVM via nested virtualization).
+All measurements from hl-dev (Azure D8s_v5, KVM, Cloud Hypervisor v44.0,
+containerd 2.2.2).
 
 ## Cold Boot
 
-Full VM lifecycle from scratch — kernel boots, agent starts, ttrpc connects.
+Full VM lifecycle from scratch — kernel boots, agent starts, container runs.
 
 | Phase | Latency |
 |-------|---------|
-| Shim setup (new + prepare) | **~0.1ms** |
-| Cloud Hypervisor startup | **~6ms** |
-| VM create + boot (CH API) | **~16ms** |
-| Guest boot + agent ready | **~231ms** |
-| ttrpc connect | **~0.3ms** |
-| **Total cold start** | **~280ms** |
-| Shutdown + cleanup | **~19ms** |
-
-End-to-end container lifecycle (boot + disk create + hot-plug + container start):
-
-| Phase | Latency |
-|-------|---------|
-| VM boot | **~250ms** |
-| Disk image create | **~31ms** |
-| Hot-plug + CreateContainer | **~64ms** |
-| StartContainer | **~2ms** |
-| **Total** | **~350ms** |
-
-## Snapshot Restore
-
-Restore from a pre-captured golden snapshot — skips kernel boot and agent initialization.
-
-| Phase | Latency |
-|-------|---------|
-| Golden snapshot creation (one-time) | **~115ms** |
-| VM restore from snapshot | **~32ms** |
-| Network hot-add (post-restore) | **~50ms** |
-| **Total restore + networking** | **~82ms** |
-
-The golden snapshot captures a fully-booted VM with the agent running. It's created
-lazily on first use and reused for all subsequent restores. Pool warming uses snapshot
-restore when available, falling back to cold boot transparently.
+| Sandbox (VM boot) | **~97ms** |
+| Container create (disk image) | **~64ms** |
+| Container start (agent RPC) | **~160ms** |
+| Exit detection | **~100ms** |
+| **Total e2e** | **~420ms** |
 
 ## Resource Overhead (per VM)
 
 | Component | RSS |
 |-----------|-----|
 | Cloud Hypervisor (VMM) | ~50 MB |
-| Shim process | ~10 MB |
+| Shim process | ~7 MB |
 | VM guest memory | 128–512 MB (configurable) |
+| **Total host overhead** | **~57 MB** |
 
-
-process instead of a separate daemon:
-
-| Metric | Spawned | Embedded |
-|--------|---------|----------|
-| RSS per VM | ~5 MB | **0** (shared in shim) |
+No virtiofsd process — block-device-only architecture (2 processes per VM).
 
 ## Density
 
@@ -62,25 +32,23 @@ At 100 VMs per node with 128 MB guest memory:
 
 | Component | Total |
 |-----------|-------|
+| Host process overhead | ~5.7 GB |
 | Guest memory | ~12.8 GB |
-| **Total** | **~19.3 GB** |
-
-With 512 MB guest memory:
-
-| Component | Total |
-|-----------|-------|
-| Host process overhead | ~6.5 GB |
-| Guest memory | ~51.2 GB |
-| **Total** | **~57.7 GB** |
+| **Total** | **~18.5 GB** |
 
 ## Comparison
 
-| | containerd-cloudhypervisor | Kata Containers |
+Benchmarked on identical hardware (Azure D8s_v5, 3 nodes):
+
+| | containerd-cloudhypervisor | Kata Containers 3.27 |
 |---|---|---|
-| **Cold start** | ~300ms boot, ~30ms snapshot restore | ~500ms–1s |
-| **Shim binary** | 2.4 MB | ~50 MB |
-| **Agent binary** | 1.5 MB (static) | ~20 MB |
-| **Guest rootfs** | 16 MB (agent + crun only) | ~150 MB |
+| **Sandbox boot** | ~97ms | ~876ms |
+| **Total e2e** | ~420ms | ~1,134ms |
+| **VMM memory (RSS)** | ~50 MB | ~144 MB |
+| **Shim memory (RSS)** | ~7 MB | ~45 MB |
+| **Shim binary** | ~4 MB | ~65 MB |
+| **Guest rootfs** | 16 MB | ~257 MB |
+| **Total on disk** | 44 MB | 651 MB |
 | **Hypervisors** | Cloud Hypervisor only | CH, QEMU, Firecracker |
-| **TCB** | Minimal | Full Linux userspace |
+| **Architecture** | Block-device-only (no FUSE) | virtio-fs + block |
 | **Language** | Rust | Go |

--- a/example/crictl/README.md
+++ b/example/crictl/README.md
@@ -126,7 +126,6 @@ sudo tee /opt/cloudhv/config.json > /dev/null <<EOF
   "kernel_args": "console=hvc0 root=/dev/vda rw init=/init net.ifnames=0",
   "default_vcpus": 1,
   "default_memory_mb": 512,
-  "pool_size": 2,
   "max_containers_per_vm": 5,
   "tpm_enabled": false
 }


### PR DESCRIPTION
Closes #30

## Summary

Restores filesystem volume support (ConfigMaps, Secrets, emptyDir, filesystem PVCs) using block devices instead of the removed virtiofsd. Volume data is baked into the container rootfs disk image during `mkfs.ext4 -d` staging — one disk per container, no extra processes, no FUSE.

## How It Works

1. Shim reads OCI spec mounts, extracts volumes (skips system mounts)
2. Filesystem volumes: source data copied into `staging/volumes/<hash>/`
3. `mkfs.ext4 -d` creates one image containing rootfs + all volume data
4. Single disk hot-plugged to VM via `vm.add-disk`
5. Agent bind-mounts volumes from the disk at expected container paths
6. Block device PVCs continue to use direct `vm.add-disk` hot-plug

## Documentation Updates

Complete rewrite of stale documentation:
- **architecture.md**: Volumes section (block-based), container logs (vsock RPC), removed snapshot/restore
- **performance.md**: Real benchmark data with Kata comparison
- **README.md, configuration.md, crictl example**: Removed virtiofsd, pool_size, snapshot references