### PR TITLE
fix: release workflow references non-existent build-installer-image job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-binaries, build-kernel, build-rootfs, build-installer-image]
+    needs: [build-binaries, build-kernel, build-rootfs]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The Docker image build steps were moved into `build-rootfs` but the `release` job still referenced the old `build-installer-image` job name in its `needs` list, causing **all** release workflow runs to fail immediately with 'workflow file issue'.

This also explains why the release workflow appeared to trigger on branch pushes — GitHub reports a workflow parse error for every push when the YAML references a non-existent job.