### PR TITLE
fix: extract build-installer-image into separate release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,13 @@ jobs:
           name: ${{ matrix.rootfs_artifact }}
           path: guest/rootfs/rootfs.ext4
 
+  build-installer-image:
+    name: Build Installer Image
+    runs-on: ubuntu-latest
+    needs: [build-binaries, build-kernel, build-rootfs]
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Download shim (x86_64)
         uses: actions/download-artifact@v4
         with:
@@ -266,7 +273,7 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-binaries, build-kernel, build-rootfs]
+    needs: [build-binaries, build-kernel, build-rootfs, build-installer-image]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The Docker image build steps were incorrectly inside the `build-rootfs` matrix job, causing x86_64 runners to try downloading aarch64 artifacts from their parallel sibling (which hadn't uploaded yet → `Artifact not found for name: vmlinux-aarch64`).

Extracts into a dedicated `build-installer-image` job with `needs: [build-binaries, build-kernel, build-rootfs]`, ensuring all arch artifacts exist before the installer image is built.

Also restores `build-installer-image` to the `release` job's `needs` list.