### PR TITLE
perf: lower RuntimeClass CPU overhead from 50m to 10m

### DIFF
--- a/charts/cloudhv-installer/values.yaml
+++ b/charts/cloudhv-installer/values.yaml
@@ -23,4 +23,4 @@ runtimeClass:
   handler: cloudhv
   overhead:
     memory: "50Mi"
-    cpu: "50m"
+    cpu: "10m"


### PR DESCRIPTION
Lowers the CloudHV RuntimeClass `podFixed.cpu` overhead from 50m to 10m to better reflect actual idle VMM cost (~10-15m) and improve pod density.

### Scheduling impact (D8s_v5, 7820m allocatable CPU)

| | Before (50m) | After (10m) |
|---|---|---|
| Per-pod CPU budget | 150m | 110m |
| Max pods/node | ~52 | ~71 |
| 3-node cluster | ~156 | ~213 |
| **150-pod burst** | 8 Pending | **All fit** |

Particularly beneficial for I/O-bound workloads (AI agents, API gateways) where CPU utilization is <5% at steady state.

Part of #30