### PR TITLE
perf: nobarrier ext4 mount + journal-free images

### DIFF
--- a/crates/agent/src/container.rs
+++ b/crates/agent/src/container.rs
@@ -125,7 +125,10 @@ impl ContainerManager {
 
         info!("discovered new disk: {}", new_disk);
 
-        // Mount the disk — retry as the device may not be immediately ready
+        // Mount the disk — retry as the device may not be immediately ready.
+        // Use noatime (skip access time updates) and nobarrier (skip journal
+        // barriers) since these are ephemeral container disks — we don't need
+        // crash consistency guarantees for data that is recreated on every start.
         #[cfg(target_os = "linux")]
         {
             use nix::mount::{mount, MsFlags};
@@ -134,8 +137,8 @@ impl ContainerManager {
                     Some(new_disk.as_str()),
                     _mount_point,
                     Some("ext4"),
-                    MsFlags::empty(),
-                    None::<&str>,
+                    MsFlags::MS_NOATIME,
+                    Some("nobarrier"),
                 ) {
                     Ok(()) => return Ok(new_disk),
                     Err(e) if attempt < 20 => {

--- a/crates/shim/src/instance.rs
+++ b/crates/shim/src/instance.rs
@@ -466,7 +466,7 @@ impl CloudHvInstance {
             f.set_len(16 * 1024 * 1024)?; // 16MB default
             drop(f);
             let status = std::process::Command::new("mkfs.ext4")
-                .args(["-q", "-F"])
+                .args(["-q", "-F", "-O", "^has_journal"])
                 .arg(&edir_path)
                 .status();
             if status.map(|s| !s.success()).unwrap_or(true) {
@@ -1076,8 +1076,11 @@ fn create_cached_rootfs_image(
         anyhow::bail!("cp rootfs to cache staging failed: {status}");
     }
 
+    // Create ext4 without journal — these are ephemeral container disks that
+    // don't need crash consistency. Saves ~4MB per image and eliminates
+    // journal write overhead on every file operation inside the guest.
     let status = Command::new("mkfs.ext4")
-        .args(["-q", "-F", "-d"])
+        .args(["-q", "-F", "-O", "^has_journal", "-d"])
         .arg(&staging)
         .arg(cache_path)
         .status()


### PR DESCRIPTION
Ephemeral container disks don't need crash consistency. Two changes:

1. **Agent mounts with `MS_NOATIME` + `nobarrier`** — skips access time updates and journal write barriers
2. **mkfs.ext4 with `-O ^has_journal`** — eliminates journal entirely from rootfs cache and emptyDir images

### Micro-benchmark (hl-dev: mount + write 4 files + sync)

| | Journal (default) | No journal + nobarrier |
|---|---|---|
| Cold | 107ms | **28ms** |
| Warm avg | ~44ms | **~22ms** |
| **Speedup** | — | **2×** |

Saves ~20ms per container start inside the guest VM.

Part of #30

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>