### PR TITLE
docs: update examples to v0.5.3 and current architecture

### DIFF
--- a/example/aks/README.md
+++ b/example/aks/README.md
@@ -19,7 +19,7 @@ CLUSTER="cloudhv-demo"
 # Create resource group
 az group create --name "$RG" --location "$REGION"
 
-# Create cluster with a system node pool
+# Create cluster with a system node pool (Azure Linux for nested virt support)
 az aks create \
   --resource-group "$RG" \
   --name "$CLUSTER" \
@@ -28,7 +28,8 @@ az aks create \
   --node-vm-size Standard_D2s_v5 \
   --nodepool-name system \
   --generate-ssh-keys \
-  --network-plugin azure
+  --network-plugin azure \
+  --os-sku AzureLinux
 
 # Add a worker pool with the cloudhv label (3 nodes with nested virt)
 az aks nodepool add \
@@ -36,8 +37,10 @@ az aks nodepool add \
   --cluster-name "$CLUSTER" \
   --name cloudhv \
   --node-count 3 \
-  --node-vm-size Standard_D4s_v5 \
-  --labels workload=cloudhv
+  --node-vm-size Standard_D8s_v5 \
+  --max-pods 60 \
+  --labels workload=cloudhv \
+  --os-sku AzureLinux
 
 # Get credentials
 az aks get-credentials --resource-group "$RG" --name "$CLUSTER"
@@ -46,18 +49,21 @@ az aks get-credentials --resource-group "$RG" --name "$CLUSTER"
 ## 2. Install the Shim with Helm
 
 The Helm chart is published to GHCR as an OCI artifact with each release.
+Check [Releases](https://github.com/devigned/containerd-cloudhypervisor/releases)
+for the latest version.
 
 ```bash
-# Install the latest release
+# Install (replace version with the latest release)
 helm install cloudhv-installer \
   oci://ghcr.io/devigned/charts/cloudhv-installer \
-  --version 0.1.3 \
+  --version 0.5.3 \
   --namespace kube-system
 ```
 
 This creates:
+- A **DaemonSet** that installs the shim binary, guest kernel, rootfs, and
   Cloud Hypervisor onto each node labeled `workload=cloudhv`
-- A **RuntimeClass** named `cloudhv` with pod overhead annotations
+- A **RuntimeClass** named `cloudhv` with pod overhead annotations (10m CPU, 50Mi memory)
 
 Verify installation:
 
@@ -78,7 +84,7 @@ Deploy an HTTP echo server as a Deployment with a Service, making it easy to
 scale up and down. Each replica runs inside its own Cloud Hypervisor microVM.
 
 ```bash
-kubectl apply -f - <<EOF
+kubectl apply -f - <<YAML
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -118,7 +124,7 @@ spec:
     - port: 80
       targetPort: 5678
   type: LoadBalancer
-EOF
+YAML
 
 # Wait for the deployment to be ready
 kubectl rollout status deployment echo-cloudhv
@@ -135,11 +141,12 @@ curl http://$EXTERNAL_IP/
 
 ### Scale Up
 
-Each new replica boots a fresh microVM in ~300-400ms (faster with rootfs caching):
+Each new replica boots a fresh microVM. With rootfs caching, subsequent pods
+of the same image start in ~300ms:
 
 ```bash
-# Scale to 5 replicas (5 VMs across 3 nodes)
-kubectl scale deployment echo-cloudhv --replicas=5
+# Scale to 150 replicas (150 VMs across 3 D8s_v5 nodes)
+kubectl scale deployment echo-cloudhv --replicas=150
 kubectl get pods -l app=echo-cloudhv -o wide -w
 ```
 
@@ -194,7 +201,8 @@ az group delete --name "$RG" --yes --no-wait
 | `image.tag` | `v<appVersion>` | Image tag |
 | `nodeSelector` | `workload: cloudhv` | Target nodes |
 | `runtimeClass.enabled` | `true` | Create RuntimeClass |
-| `runtimeClass.overhead.memory` | `50Mi` | Pod overhead |
+| `runtimeClass.overhead.cpu` | `10m` | Pod CPU overhead |
+| `runtimeClass.overhead.memory` | `50Mi` | Pod memory overhead |
 
 See [`charts/cloudhv-installer/values.yaml`](../../charts/cloudhv-installer/values.yaml)
 for all configurable values.

--- a/example/crictl/README.md
+++ b/example/crictl/README.md
@@ -109,7 +109,7 @@ cd guest/kernel && bash build-kernel.sh && cd ../..
 cd guest/rootfs && sudo bash build-rootfs.sh ../../target/x86_64-unknown-linux-musl/release/cloudhv-agent && cd ../..
 
 # Install guest artifacts
-sudo mkdir -p /opt/cloudhv
+sudo mkdir -p /opt/cloudhv /opt/cloudhv/cache
 sudo cp guest/kernel/vmlinux /opt/cloudhv/vmlinux
 sudo cp guest/rootfs/rootfs.ext4 /opt/cloudhv/rootfs.ext4
 ```
@@ -211,10 +211,10 @@ echo "Container started: $CTR_ID"
 ```
 
 Behind the scenes:
-1. The shim creates an ext4 disk image from the container's rootfs
+1. The shim clones a cached rootfs ext4 image (or creates the cache on first use)
 2. Hot-plugs it into the running VM via Cloud Hypervisor's `vm.add-disk` API
-3. The guest agent discovers the new `/dev/vdX` device and mounts it
-4. `crun` runs the container with mount + PID namespace isolation
+3. Sends config.json + volume data inline via the CreateContainer RPC
+4. The guest agent mounts the disk, writes metadata, and runs `crun`
 
 ### Verify it works
 
@@ -299,10 +299,11 @@ crictl runp sandbox.json
     → shim reports sandbox ready to containerd
 
 crictl create $POD container.json sandbox.json
-  → shim creates ext4 disk image from container rootfs
+  → shim clones cached rootfs image (or creates cache on first use)
   → shim calls vm.add-disk to hot-plug into the VM
-  → agent discovers /dev/vdX, mounts it
-  → agent runs crun with the OCI spec
+  → shim sends config.json + volume data inline via CreateContainer RPC
+  → agent discovers /dev/vdX, mounts it, writes metadata
+  → agent runs crun with the adapted OCI spec
   → shim forwards container stdout/stderr to containerd
 
 crictl stopp $POD


### PR DESCRIPTION
Updates both example READMEs to reflect the current release and architecture.

- AKS: Helm version 0.1.3 → 0.5.3, D4s_v5 → D8s_v5, added AzureLinux/max-pods, fixed Helm values table
- crictl: added cache dir, updated architecture descriptions for rootfs cache + inline RPC