### PR TITLE
fix: bake cloud-hypervisor binary into installer image

### DIFF
--- a/installer/Dockerfile
+++ b/installer/Dockerfile
@@ -73,15 +73,26 @@ RUN mkdir -p rootfs/bin rootfs/dev/pts rootfs/dev/shm rootfs/etc \
 # --- Stage 4: Final installer image ---
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y \
-    python3 jq curl \
-    && rm -rf /var/lib/apt/lists/*
+# Download cloud-hypervisor at build time (not at runtime on the node).
+# TARGETARCH is set by Docker buildx (amd64 or arm64).
+ARG CH_VERSION=v44.0
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+      CH_SUFFIX="static-aarch64"; \
+    else \
+      CH_SUFFIX="static"; \
+    fi && \
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && \
+    curl -sL "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${CH_VERSION}/cloud-hypervisor-${CH_SUFFIX}" \
+      -o /opt/cloud-hypervisor && chmod 755 /opt/cloud-hypervisor && \
+    apt-get purge -y curl && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/cloudhv
 
 COPY --from=builder /src/target/release/containerd-shim-cloudhv-v1 ./
 COPY --from=kernel-builder /kernel/vmlinux ./
 COPY --from=rootfs-builder /rootfs/rootfs.ext4 ./
+RUN cp /opt/cloud-hypervisor ./cloud-hypervisor
 COPY installer/install.sh ./
 
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -15,11 +15,9 @@ HOST=/host
 HOST_ARCH="$(uname -m)"
 case "${HOST_ARCH}" in
     x86_64)
-        CH_ARCH_SUFFIX="static"
         KERNEL_CONSOLE="console=ttyS0"
         ;;
     aarch64)
-        CH_ARCH_SUFFIX="static-aarch64"
         KERNEL_CONSOLE="console=ttyAMA0"
         ;;
     *)
@@ -241,11 +239,8 @@ DMCONF
 fi
 
 if [ ! -f "$HOST/usr/local/bin/cloud-hypervisor" ]; then
-  echo "[cloudhv] Installing cloud-hypervisor (${HOST_ARCH})..."
-  CH_VERSION="v44.0"
-  curl -sL "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${CH_VERSION}/cloud-hypervisor-${CH_ARCH_SUFFIX}" \
-    -o "$HOST/usr/local/bin/cloud-hypervisor"
-  chmod 755 "$HOST/usr/local/bin/cloud-hypervisor"
+  echo "[cloudhv] Copying cloud-hypervisor binary (${HOST_ARCH})..."
+  install -m 755 "$ARTIFACTS/cloud-hypervisor" "$HOST/usr/local/bin/cloud-hypervisor"
 fi
 
 # 6. Schedule a deferred containerd restart on the host.


### PR DESCRIPTION
Downloads CH during `docker build` instead of at runtime via `curl` on the node. This removes the runtime dependency on GitHub connectivity and eliminates a silent hang when the download fails.

Also removes `python3`, `jq`, and `curl` from the final image since they're no longer needed.