### PR TITLE
Update sysext to include daemon, add sysext test to CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  CH_VERSION: "v44.0"
+  CH_VERSION: "v51.1"
   KERNEL_SERIES: "6.18"
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install sysext test dependencies
+        run: sudo apt-get update && sudo apt-get install -y qemu-system python3
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -232,6 +235,12 @@ jobs:
           # Stop daemon
           sudo kill $DAEMON_PID 2>/dev/null || true
           wait $DAEMON_PID 2>/dev/null || true
+
+      - name: Run sysext / Flatcar VM integration tests
+        if: env.KVM_AVAILABLE == 'true'
+        run: |
+          set -e
+          hacks/test-sysext.sh
 
       - name: Fix cargo cache permissions
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ vmlinux*
 rootfs.erofs
 cloudhv-agent
 containerd-shim-cloudhv-v1
+cloudhv-sandbox-daemon
 mkfs.erofs
 containerd-cloudhypervisor.raw
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ containerd-shim-cloudhv-v1
 mkfs.erofs
 containerd-cloudhypervisor.raw
 
+# sysext bakery may be used for local sysext testing
+sysext-bakery
+
 # Cargo lock for binaries is committed
 # Cargo.lock
 

--- a/hacks/Readme.md
+++ b/hacks/Readme.md
@@ -14,6 +14,9 @@ Scripts are meant to be called from the repository root, and should be invoked w
 * `hacks/build-sysext.sh` - Will build a system extension image with guest (L2) and host bits, including host configuration.
   - will put `containerd-cloudhypervisor.raw` into the repo root.
     See [main readme](../README.md#test-your-builds-locally-in-a-flatcar-vm) for usage instructions.
+* `hacks/test-sysext.sh` - Will boot a Flatcar VM with the sysext in the repo root, run `/usr/share/cloudhv/demo/demo.sh`, and exit with the demo's exit code.
+  - needs `containerd-cloudhypervisor.raw` present in the repo root.
+  - will clone the [sysext bakery](https://github.com/flatcar/sysext-bakery/) repo locally and use `bakery.sh boot` to run the test.
 
 ## Building for different architectures
 

--- a/hacks/build-sysext.sh
+++ b/hacks/build-sysext.sh
@@ -11,7 +11,7 @@ scriptdir="$(cd "$(dirname "$0")"; pwd)"
 source "${scriptdir}/util.inc"
 
 CNI_VERSION="${CNI_VERSION:-v1.9.1}"
-CH_VERSION="${CH_VERSION:-v44.0}"
+CH_VERSION="${CH_VERSION:-v51.1}"
 
 # Runs inside the container
 build() {
@@ -25,6 +25,7 @@ build() {
 
   build_if_missing "$host_user_group" /host/hacks/build-guest.sh -- vmlinux vmlinux.kconfig rootfs.erofs
   build_if_missing "$host_user_group" /host/hacks/build-static-rust.sh containerd-shim-cloudhv -- containerd-shim-cloudhv-v1
+  build_if_missing "$host_user_group" /host/hacks/build-static-rust.sh cloudhv-sandbox-daemon -- cloudhv-sandbox-daemon
   build_if_missing "$host_user_group" /host/hacks/build-host-deps.sh -- mkfs.erofs
 
   cd sysext
@@ -33,8 +34,10 @@ build() {
            root/usr/libexec/cni
 
   cp /host/vmlinux /host/vmlinux.kconfig /host/rootfs.erofs root/usr/share/cloudhv/guest/
-  cp /host/containerd-shim-cloudhv-v1 root/usr/bin
-  cp /host/mkfs.erofs root/usr/bin
+  cp /host/containerd-shim-cloudhv-v1 \
+     /host/cloudhv-sandbox-daemon \
+     /host/mkfs.erofs \
+        root/usr/bin
 
   local arch="$(translate_arch)"
   sed -i "s/^ARCHITECTURE=.*/ARCHITECTURE=${arch}/" \

--- a/hacks/test-sysext.sh
+++ b/hacks/test-sysext.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Test script for the sysext demo
+#
+
+set -euo pipefail
+
+function read_until() {
+  local fd="$1"
+  shift
+  local match_string="${@}"
+
+  echo "Read until: looking for '${match_string}'"
+
+  local line
+  while read -ru ${fd} line; do \
+    echo "VM :: $line"
+    if [[ "$line" == *"${match_string}"* ]] ; then
+      echo -e "\n MATCH: '${match_string}'"
+      break
+    fi
+  done
+}
+# --
+
+function child_procs() {
+  local ppid="$(ps -o pid= --ppid $1 | tr -d '\n')"
+  if [[ -n "$ppid" ]]; then
+    echo -n "$ppid "
+    child_procs "$ppid"
+  fi
+}
+# --
+
+if [[ ! -f containerd-cloudhypervisor.raw ]]; then
+  echo "ERROR: system extension image 'containerd-cloudhypervisor.raw' not found."
+  exit 1
+fi
+
+echo "Fetching bakery for Flatcar VM automation"
+if [[ ! -d sysext-bakery ]]; then 
+  git clone --depth 1 https://github.com/flatcar/sysext-bakery.git
+fi
+cp containerd-cloudhypervisor.raw sysext-bakery
+cd sysext-bakery
+
+echo "Running the test (includes Flatcar image download)"
+coproc flatcar { ./bakery.sh boot containerd-cloudhypervisor.raw 2>&1; }
+read_until "${flatcar[0]}" "localhost login:"
+sleep 1
+echo "sudo /usr/share/cloudhv/demo/demo.sh; rc=\"\$?\"; echo 'TEST_IS_DONE'; echo \"TEST_EXIT_CODE=\$rc\"" >&${flatcar[1]}
+read_until "${flatcar[0]}" "TEST_IS_DONE" # input is echoed on the console
+read_until "${flatcar[0]}" "TEST_IS_DONE"
+read -ru "${flatcar[0]}" exit_code_line
+
+exit_code="$(echo "${exit_code_line}" | sed 's/.*TEST_EXIT_CODE=\([0-9]*\).*/\1/')"
+echo "Exit code is '$exit_code'"
+kill -9 $(child_procs "$flatcar_PID")
+
+exit $exit_code

--- a/hacks/test-sysext.sh
+++ b/hacks/test-sysext.sh
@@ -48,7 +48,7 @@ echo "Running the test (includes Flatcar image download)"
 coproc flatcar { ./bakery.sh boot containerd-cloudhypervisor.raw 2>&1; }
 read_until "${flatcar[0]}" "localhost login:"
 sleep 1
-echo "sudo /usr/share/cloudhv/demo/demo.sh; rc=\"\$?\"; echo 'TEST_IS_DONE'; echo \"TEST_EXIT_CODE=\$rc\"" >&${flatcar[1]}
+echo "sudo /usr/share/cloudhv/demo/demo.sh cleanup; rc=\"\$?\"; echo 'TEST_IS_DONE'; echo \"TEST_EXIT_CODE=\$rc\"" >&${flatcar[1]}
 read_until "${flatcar[0]}" "TEST_IS_DONE" # input is echoed on the console
 read_until "${flatcar[0]}" "TEST_IS_DONE"
 read -ru "${flatcar[0]}" exit_code_line

--- a/sysext/root/usr/lib/systemd/system/cloudhv-sandbox-daemon.service
+++ b/sysext/root/usr/lib/systemd/system/cloudhv-sandbox-daemon.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=CloudHV Sandbox Daemon
+After=containerd.service
+Requires=containerd.service
+
+[Service]
+ExecStartPre=/bin/mkdir -p /run/cloudhv/daemon
+Environment=RUST_LOG=info
+ExecStart=/usr/bin/cloudhv-sandbox-daemon /opt/cloudhv/daemon.json
+Restart=always
+RestartSec=5
+MemoryMax=4G
+
+[Install]
+WantedBy=multi-user.target

--- a/sysext/root/usr/lib/systemd/system/multi-user.target.d/10-cloudhv-sandbox-daemon.conf
+++ b/sysext/root/usr/lib/systemd/system/multi-user.target.d/10-cloudhv-sandbox-daemon.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=cloudhv-sandbox-daemon.service

--- a/sysext/root/usr/lib/tmpfiles.d/10-containerd-cloudhypervisor.conf
+++ b/sysext/root/usr/lib/tmpfiles.d/10-containerd-cloudhypervisor.conf
@@ -1,4 +1,5 @@
 C /opt/cloudhv/config.json - - - - /usr/share/cloudhv/config.json
+C /opt/cloudhv/daemon.json - - - - /usr/share/cloudhv/daemon.json
 C /opt/cloudhv/guest - - - - /usr/share/cloudhv/guest
 C /etc/cni/net.d/10-bridge.conflist - - - - /usr/share/cloudhv/etc/cni/net.d/10-bridge.conflist
 C /etc/crictl.yaml - - - - /usr/share/cloudhv/etc/crictl.yaml

--- a/sysext/root/usr/share/cloudhv/config.json
+++ b/sysext/root/usr/share/cloudhv/config.json
@@ -4,7 +4,11 @@
   "rootfs_path": "/opt/cloudhv/guest/rootfs.erofs",
   "kernel_args": "console=hvc0 root=/dev/vda rw init=/init net.ifnames=0",
   "default_vcpus": 1,
-  "default_memory_mb": 512,
+  "max_default_vcpus": 0,
+  "default_memory_mb": 128,
+  "hotplug_memory_mb": 0,
+  "hotplug_method": "acpi",
   "max_containers_per_vm": 5,
-  "tpm_enabled": false
+  "tpm_enabled": false,
+  "daemon_socket": "/run/cloudhv/daemon.sock"
 }

--- a/sysext/root/usr/share/cloudhv/daemon.json
+++ b/sysext/root/usr/share/cloudhv/daemon.json
@@ -1,0 +1,11 @@
+{
+  "pool_size": 3,
+  "cloud_hypervisor_binary": "/usr/bin/cloud-hypervisor",
+  "kernel_path": "/opt/cloudhv/guest/vmlinux",
+  "rootfs_path": "/opt/cloudhv/guest/rootfs.erofs",
+  "kernel_args": "${KERNEL_CONSOLE} root=/dev/vda rw init=/init net.ifnames=0",
+  "default_vcpus": 1,
+  "default_memory_mb": 128,
+  "socket_path": "/run/cloudhv/daemon.sock",
+  "state_dir": "/run/cloudhv/daemon"
+}

--- a/sysext/root/usr/share/cloudhv/demo/demo.sh
+++ b/sysext/root/usr/share/cloudhv/demo/demo.sh
@@ -3,45 +3,88 @@
 # containerd-cloudhypervisor "echo" demo
 #
 
-set -euo pipefail
-
-scriptdir="$(cd "$(dirname "$0")"; pwd)"
-cfg_box="${scriptdir}/demo-sandbox.json"
-cfg_cont="${scriptdir}/demo-container.json"
-
 function announce() {
   echo -e "\n  * $@\n"
 }
 # --
 
-pod_id_file="$(mktemp)"
-cont_id_file="$(mktemp)"
-# used by sandbox config for logging
-mkdir -p /tmp/echo-pod-logs
-trap "rm -rf '$pod_id_file' '$cont_id_file' '/tmp/echo-pod-logs'" EXIT
+function get_cont_id() {
+  crictl ps --all -o json \
+     | jq -r '.containers[] | select( .metadata.name == "echo-server") | "\(.id)"'
+}
+# --
 
-announce "Pulling 'echo' container image"
-crictl pull hashicorp/http-echo:latest
+function get_pod_id() {
+  crictl pods -o json \
+     | jq -r '.items[] | select( .metadata.uid == "echo-pod-uid") | "\(.id)"'
+}
+# --
 
-announce "Creating Sandbox VM pod"
-crictl runp --runtime=cloudhv "$cfg_box" | tee "$pod_id_file"
-pod_id="$(cat "$pod_id_file")"
-pod_ip="$(crictl inspectp "$pod_id" | jq -r '.status.network.ip')"
-echo "Pod has IP address '$pod_ip'"
+function cleanup() {
+  set +e
+  local cont_id="$(get_cont_id)"
+  local pod_id="$(get_pod_id)"
 
-announce "Creating and starting 'echo' container"
-crictl create "$pod_id" "$cfg_cont" "$cfg_box" | tee "$cont_id_file"
-cont_id="$(cat "$cont_id_file")"
-crictl start "$cont_id"
+  if [[ -n "${cont_id}" ]] ; then
+    echo "Cleanup: Stopping and removing container '${cont_id}'"
+    crictl stop "${cont_id}"
+    crictl rm "${cont_id}"
+  fi
 
-sleep 1
-announce "Accessing echo container HTTP endpoint"
-curl -sSL http://"$pod_ip":5678
+  if [[ -n "${pod_id}" ]] ; then
+    echo "Cleanup: Stopping and removing pod '${pod_id}'"
+    crictl stopp "${pod_id}"
+    crictl rmp "${pod_id}"
+  fi
+}
+# --
 
-announce "Printing container logs"
-for f in /tmp/echo-pod-logs/*; do
-  echo " ### $f ###"
-  cat "$f"
-done
+function demo() {
 
-announce "All done. Bye bye."
+  set -euo pipefail
+
+  local scriptdir cfg_box cfg_cont
+  scriptdir="$(cd "$(dirname "$0")"; pwd)"
+  cfg_box="${scriptdir}/demo-sandbox.json"
+  cfg_cont="${scriptdir}/demo-container.json"
+
+  # used by sandbox config for logging
+  mkdir -p /tmp/echo-pod-logs
+
+  if [[ "${@}" == *"cleanup"* ]]; then
+    trap cleanup exit
+  fi
+
+  announce "Pulling 'echo' container image"
+  crictl pull hashicorp/http-echo:latest
+
+  announce "Creating Sandbox VM pod"
+  crictl runp --runtime=cloudhv "$cfg_box"
+  local pod_id pod_ip
+  pod_id="$(get_pod_id)"
+  pod_ip="$(crictl inspectp "$pod_id" | jq -r '.status.network.ip')"
+  echo "Pod has IP address '$pod_ip'"
+
+  announce "Creating and starting 'echo' container"
+  crictl create "$pod_id" "$cfg_cont" "$cfg_box"
+  local cont_id
+  cont_id="$(get_cont_id)"
+  crictl start "$cont_id"
+
+  sleep 1
+  announce "Accessing echo container HTTP endpoint"
+  curl -sSL http://"$pod_ip":5678
+
+  announce "Printing container logs"
+  for f in /tmp/echo-pod-logs/*; do
+    echo " ### $f ###"
+    cat "$f"
+  done
+
+  announce "All done. Bye bye."
+}
+# --
+
+if [[ "$0" != "-bash" ]] && [[ "$(basename "$0")" = "demo.sh" ]] ; then
+  demo "${@}"
+fi


### PR DESCRIPTION
This change includes `cloudhv-sandbox-daemon` in the sysext, and adds `hacks/test-sysext.sh`, which will run an integration test with the system extension image. The image must have been built prior to running the test, and must be present in the repository root.

The test uses the sysext bakery's `bakery.sh boot` feature to start a VM, then runs the `demo.sh` script included with the system extension image.

The test is also added to the integration tests in `ci.yaml`.

https://github.com/devigned/containerd-cloudhypervisor/pull/86 broke pod networking for me, and https://github.com/devigned/containerd-cloudhypervisor/pull/93 partially fixed it. When running `demo.sh`, the container refuses to start. Therefore, the sysext integration test currently fails at the ["start" step](https://github.com/devigned/containerd-cloudhypervisor/blob/main/sysext/root/usr/share/cloudhv/demo/demo.sh#L35), with: 

```
E0324 07:23:01.346740    3087 log.go:32] "StartContainer from runtime service failed" err="rpc error: code = Unknown desc = failed to start containerd task \"616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0\": daemon acquire: daemon AcquireSandbox: run container: networking setup: prepare_tap: find gw: not found after 20 retries" containerID="616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0"
FATA[0002] starting the container "616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0": rpc error: code = Unknown desc = failed to start containerd task "616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0": daemon acquire: daemon AcquireSandbox: run container: networking setup: prepare_tap: find gw: not found after 20 retries
```

# Repro

Steps to reproduce:
- clone this branch
- `bash hacks/build_sysext.sh`
- `bash hacks/test-sysext.sh`

Manual repro in local VM:
- clone this branch
- `bash hacks/build_sysext.sh`
- `git clone --depth 1 https://github.com/flatcar/sysext-bakery.git`
- `cp containerd-cloudhypervisor.raw sysext-bakery/`
- `cd sysext-bakery`
- `./bakery.sh boot containerd-cloudhypervisor.raw`

After the VM booted, run the [demo](https://github.com/devigned/containerd-cloudhypervisor/blob/main/sysext/root/usr/share/cloudhv/demo/demo.sh)
- `sudo /usr/share/cloudhv/demo/demo.sh`

You can also connect to the VM via SSH for debugging:
- `ssh -p 2222 core@localhost`

# Logs

cloudhv-sandbox-daemon
```
Mar 24 07:22:48 localhost systemd[1]: Starting cloudhv-sandbox-daemon.service - CloudHV Sandbox Daemon...
Mar 24 07:22:48 localhost systemd[1]: Started cloudhv-sandbox-daemon.service - CloudHV Sandbox Daemon.
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon] cloudhv-sandbox-daemon starting (version 0.1.0)
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon] config: /opt/cloudhv/daemon.json
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon] pool_size: 3, memory: 128MiB, vcpus: 1
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon::pool] reusing existing base snapshot at /run/cloudhv/daemon/base-snapshot
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon::pool] filling pool to 3 VMs...
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon::pool] TIMING restore_one pool-2858-3: prepare=0ms spawn=0ms ch_ready=11ms restore=35ms resume=2ms agent=7ms total=55ms
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon::pool] pool VM 1/3 ready: pool-2858-3 (cid=3, pid=2879)
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon::pool] TIMING restore_one pool-2858-4: prepare=0ms spawn=1ms ch_ready=11ms restore=35ms resume=2ms agent=5ms total=54ms
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon::pool] pool VM 2/3 ready: pool-2858-4 (cid=4, pid=2888)
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon::pool] TIMING restore_one pool-2858-5: prepare=0ms spawn=0ms ch_ready=12ms restore=35ms resume=1ms agent=6ms total=54ms
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon::pool] pool VM 3/3 ready: pool-2858-5 (cid=5, pid=2897)
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon::pool] pool initialized: 3/3 VMs ready
Mar 24 07:22:48 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:48Z INFO  cloudhv_sandbox_daemon::api] daemon API listening on /run/cloudhv/daemon.sock
Mar 24 07:22:59 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:59Z DEBUG cloudhv_sandbox_daemon::api] request: method=AcquireSandbox vm_id=- container_id=616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0
Mar 24 07:22:59 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:59Z INFO  cloudhv_sandbox_daemon::pool] acquired pool VM pool-2858-5 (pool=2 active=1)
Mar 24 07:22:59 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:59Z INFO  cloudhv_sandbox_daemon::shadow] shadow VM triggered for image_key=6b54f557a2a86b965e534e8f0fd214a2
Mar 24 07:22:59 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:59Z INFO  cloudhv_sandbox_daemon::pool] acquired pool VM pool-2858-4 (pool=1 active=2)
Mar 24 07:22:59 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:59Z INFO  cloudhv_sandbox_daemon::shadow] shadow VM shadow-6b54f557a2a86b965e534e8f0fd214a2-2858 using pool VM pool-2858-4 (pid=2888)
Mar 24 07:22:59 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:59Z INFO  cloudhv_sandbox_daemon::shadow] shadow shadow-6b54f557a2a86b965e534e8f0fd214a2-2858: rootfs hot-plugged (0ms)
Mar 24 07:22:59 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:59Z INFO  cloudhv_sandbox_daemon::shadow] shadow shadow-6b54f557a2a86b965e534e8f0fd214a2-2858: container started (pid=41, 78ms)
Mar 24 07:22:59 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:59Z INFO  cloudhv_sandbox_daemon::shadow] shadow shadow-6b54f557a2a86b965e534e8f0fd214a2-2858: warming up for 30s...
Mar 24 07:22:59 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:59Z INFO  cloudhv_sandbox_daemon::pool] TIMING restore_one pool-2858-6: prepare=0ms spawn=1ms ch_ready=11ms restore=36ms resume=2ms agent=5ms total=55ms
Mar 24 07:22:59 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:22:59Z INFO  cloudhv_sandbox_daemon::pool] pool replenished: pool-2858-6 (pool=2)
Mar 24 07:23:01 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:23:01Z INFO  cloudhv_sandbox_daemon::api] responded: {"error":"run container: networking setup: prepare_tap: find gw: not found after 20 retries"}
Mar 24 07:23:01 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:23:01Z DEBUG cloudhv_sandbox_daemon::api] request: method=ReleaseSandbox vm_id= container_id=-
Mar 24 07:23:01 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:23:01Z INFO  cloudhv_sandbox_daemon::api] responded: {"error":"vm_id required"}
Mar 24 07:23:29 localhost cloudhv-sandbox-daemon[2858]: [2026-03-24T07:23:29Z WARN  cloudhv_sandbox_daemon::shadow] shadow VM failed for image_key=6b54f557a2a86b965e534e8f0fd214a2: CH API PUT /api/v1/vm.snapshot: 500 Internal Server Error ["Error from API","The VM could not be snapshotted","Cannot send VM snapshot","Failed to send migratable component snapshot","File exists (os error 17)"]
```


containerd:
```
Mar 24 07:22:39 localhost systemd[1]: Starting containerd.service - containerd container runtime...
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39Z" level=warning msg="Ignoring unknown key in TOML" column=1 error="strict mode: fields in the document are missing in the target struct" file=/etc/containerd.toml key=subreaper row=8
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.418966371Z" level=info msg="starting containerd" revision=1c4457e00facac03ce1d75f7b6777a7a851e5c41 version=v2.2.0
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.424943830Z" level=warning msg="Configuration migrated from version 2, use `containerd config migrate` to avoid migration" t="7.926µs"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.424964267Z" level=info msg="loading plugin" id=io.containerd.content.v1.content type=io.containerd.content.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425083968Z" level=info msg="loading plugin" id=io.containerd.image-verifier.v1.bindir type=io.containerd.image-verifier.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425098044Z" level=info msg="loading plugin" id=io.containerd.internal.v1.opt type=io.containerd.internal.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425122138Z" level=info msg="loading plugin" id=io.containerd.warning.v1.deprecations type=io.containerd.warning.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425128070Z" level=info msg="loading plugin" id=io.containerd.mount-handler.v1.erofs type=io.containerd.mount-handler.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425133580Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.blockfile type=io.containerd.snapshotter.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425144730Z" level=info msg="skip loading plugin" error="no scratch file generator: skip plugin" id=io.containerd.snapshotter.v1.blockfile type=io.containerd.snapshotter.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425149369Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.btrfs type=io.containerd.snapshotter.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425236409Z" level=info msg="skip loading plugin" error="path /var/lib/containerd/io.containerd.snapshotter.v1.btrfs (ext4) must be a btrfs filesystem to be used with the btrfs snapshotter: skip plugin" id=io.containerd.snapshotter.v1.btrfs type=io.containerd.snapshotter.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425246358Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.devmapper type=io.containerd.snapshotter.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425257688Z" level=info msg="skip loading plugin" error="devmapper not configured: skip plugin" id=io.containerd.snapshotter.v1.devmapper type=io.containerd.snapshotter.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425262427Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.erofs type=io.containerd.snapshotter.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425307010Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.native type=io.containerd.snapshotter.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425323880Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.overlayfs type=io.containerd.snapshotter.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425379142Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.zfs type=io.containerd.snapshotter.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425397477Z" level=info msg="skip loading plugin" error="lstat /var/lib/containerd/io.containerd.snapshotter.v1.zfs: no such file or directory: skip plugin" id=io.containerd.snapshotter.v1.zfs type=io.containerd.snapshotter.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425407165Z" level=info msg="loading plugin" id=io.containerd.event.v1.exchange type=io.containerd.event.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425427151Z" level=info msg="loading plugin" id=io.containerd.monitor.task.v1.cgroups type=io.containerd.monitor.task.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425620487Z" level=info msg="loading plugin" id=io.containerd.metadata.v1.bolt type=io.containerd.metadata.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425648169Z" level=info msg="metadata content store policy set" policy=shared
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425790421Z" level=info msg="loading plugin" id=io.containerd.gc.v1.scheduler type=io.containerd.gc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425815999Z" level=info msg="loading plugin" id=io.containerd.nri.v1.nri type=io.containerd.nri.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425834152Z" level=info msg="built-in NRI default validator is disabled"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425837518Z" level=info msg="runtime interface created"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425840173Z" level=info msg="created NRI interface"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.425844040Z" level=info msg="loading plugin" id=io.containerd.differ.v1.erofs type=io.containerd.differ.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426509057Z" level=info msg="loading plugin" id=io.containerd.differ.v1.walking type=io.containerd.differ.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426542469Z" level=info msg="loading plugin" id=io.containerd.lease.v1.manager type=io.containerd.lease.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426555453Z" level=info msg="loading plugin" id=io.containerd.mount-manager.v1.bolt type=io.containerd.mount-manager.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426603602Z" level=info msg="loading plugin" id=io.containerd.service.v1.containers-service type=io.containerd.service.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426618820Z" level=info msg="loading plugin" id=io.containerd.service.v1.content-service type=io.containerd.service.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426629149Z" level=info msg="loading plugin" id=io.containerd.service.v1.diff-service type=io.containerd.service.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426635751Z" level=info msg="loading plugin" id=io.containerd.service.v1.images-service type=io.containerd.service.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426642213Z" level=info msg="loading plugin" id=io.containerd.service.v1.introspection-service type=io.containerd.service.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426652191Z" level=info msg="loading plugin" id=io.containerd.service.v1.namespaces-service type=io.containerd.service.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426656780Z" level=info msg="loading plugin" id=io.containerd.service.v1.snapshots-service type=io.containerd.service.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426660547Z" level=info msg="loading plugin" id=io.containerd.shim.v1.manager type=io.containerd.shim.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426665847Z" level=info msg="loading plugin" id=io.containerd.runtime.v2.task type=io.containerd.runtime.v2
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426719976Z" level=info msg="loading plugin" id=io.containerd.service.v1.tasks-service type=io.containerd.service.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426734393Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.containers type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426745313Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.content type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426752156Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.diff type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426759650Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.events type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426764589Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.images type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426769629Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.introspection type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426773725Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.leases type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426780949Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.mounts type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426784726Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.namespaces type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426790366Z" level=info msg="loading plugin" id=io.containerd.sandbox.store.v1.local type=io.containerd.sandbox.store.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426795005Z" level=info msg="loading plugin" id=io.containerd.transfer.v1.local type=io.containerd.transfer.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426810193Z" level=info msg="loading plugin" id=io.containerd.cri.v1.images type=io.containerd.cri.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426833756Z" level=info msg="Get image filesystem path \"/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs\" for snapshotter \"overlayfs\""
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426839156Z" level=info msg="Start snapshots syncer"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.426855837Z" level=info msg="loading plugin" id=io.containerd.cri.v1.runtime type=io.containerd.cri.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427003941Z" level=info msg="starting cri plugin" config="{\"containerd\":{\"defaultRuntimeName\":\"runc\",\"runtimes\":{\"cloudhv\":{\"runtimeType\":\"io.containerd.cloudhv.v1\",\"runtimePath\":\"\",\"PodAnnotations\":null,\"ContainerAnnotations\":null,\"options\":null,\"privileged_without_host_devices\":false,\"privileged_without_host_devices_all_devices_allowed\":false,\"cgroupWritable\":false,\"baseRuntimeSpec\":\"\",\"cniConfDir\":\"\",\"cniMaxConfNum\":0,\"snapshotter\":\"\",\"sandboxer\":\"podsandbox\",\"io_type\":\"\"},\"runc\":{\"runtimeType\":\"io.containerd.runc.v2\",\"runtimePath\":\"\",\"PodAnnotations\":null,\"ContainerAnnotations\":null,\"options\":{\"BinaryName\":\"\",\"CriuImagePath\":\"\",\"CriuWorkPath\":\"\",\"IoGid\":0,\"IoUid\":0,\"NoNewKeyring\":false,\"Root\":\"\",\"ShimCgroup\":\"\",\"SystemdCgroup\":true},\"privileged_without_host_devices\":false,\"privileged_without_host_devices_all_devices_allowed\":false,\"cgroupWritable\":false,\"baseRuntimeSpec\":\"\",\"cniConfDir\":\"\",\"cniMaxConfNum\":0,\"snapshotter\":\"\",\"sandboxer\":\"podsandbox\",\"io_type\":\"\"}},\"ignoreBlockIONotEnabledErrors\":false,\"ignoreRdtNotEnabledErrors\":false},\"cni\":{\"binDir\":\"\",\"binDirs\":[\"/usr/libexec/cni\"],\"confDir\":\"/etc/cni/net.d\",\"maxConfNum\":1,\"setupSerially\":false,\"confTemplate\":\"\",\"ipPref\":\"\",\"useInternalLoopback\":false},\"enableSelinux\":true,\"selinuxCategoryRange\":1024,\"maxContainerLogLineSize\":16384,\"disableApparmor\":false,\"restrictOOMScoreAdj\":false,\"disableProcMount\":false,\"unsetSeccompProfile\":\"\",\"tolerateMissingHugetlbController\":true,\"disableHugetlbController\":true,\"device_ownership_from_security_context\":false,\"ignoreImageDefinedVolumes\":false,\"netnsMountsUnderStateDir\":false,\"enableUnprivilegedPorts\":true,\"enableUnprivilegedICMP\":true,\"enableCDI\":true,\"cdiSpecDirs\":[\"/etc/cdi\",\"/var/run/cdi\"],\"drainExecSyncIOTimeout\":\"0s\",\"ignoreDeprecationWarnings\":null,\"containerdRootDir\":\"/var/lib/containerd\",\"containerdEndpoint\":\"/run/containerd/containerd.sock\",\"rootDir\":\"/var/lib/containerd/io.containerd.grpc.v1.cri\",\"stateDir\":\"/run/containerd/io.containerd.grpc.v1.cri\"}"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427059252Z" level=info msg="loading plugin" id=io.containerd.podsandbox.controller.v1.podsandbox type=io.containerd.podsandbox.controller.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427100238Z" level=info msg="loading plugin" id=io.containerd.sandbox.controller.v1.shim type=io.containerd.sandbox.controller.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427128991Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.sandbox-controllers type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427137366Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.sandboxes type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427141825Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.snapshots type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427146002Z" level=info msg="loading plugin" id=io.containerd.streaming.v1.manager type=io.containerd.streaming.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427150952Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.streaming type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427155610Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.tasks type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427159327Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.transfer type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427163776Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.version type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427167211Z" level=info msg="loading plugin" id=io.containerd.monitor.container.v1.restart type=io.containerd.monitor.container.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427202516Z" level=info msg="loading plugin" id=io.containerd.tracing.processor.v1.otlp type=io.containerd.tracing.processor.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427215691Z" level=info msg="skip loading plugin" error="skip plugin: tracing endpoint not configured" id=io.containerd.tracing.processor.v1.otlp type=io.containerd.tracing.processor.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427219829Z" level=info msg="loading plugin" id=io.containerd.internal.v1.tracing type=io.containerd.internal.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427224708Z" level=info msg="skip loading plugin" error="skip plugin: tracing endpoint not configured" id=io.containerd.internal.v1.tracing type=io.containerd.internal.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427227973Z" level=info msg="loading plugin" id=io.containerd.ttrpc.v1.otelttrpc type=io.containerd.ttrpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427232191Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.healthcheck type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427236700Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.cri type=io.containerd.grpc.v1
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427241449Z" level=info msg="Connect containerd service"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.427252038Z" level=info msg="using experimental NRI integration - disable nri plugin to prevent this"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.434262943Z" level=info msg="Start subscribing containerd event"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.434319578Z" level=info msg="Start recovering state"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.434394406Z" level=info msg=serving... address=/run/containerd/containerd.sock.ttrpc
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.434481707Z" level=info msg=serving... address=/run/containerd/containerd.sock
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.439467596Z" level=info msg="Start event monitor"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.439491480Z" level=info msg="Start cni network conf syncer for default"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.439500307Z" level=info msg="Start streaming server"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.439505466Z" level=info msg="Registered namespace \"k8s.io\" with NRI"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.439509774Z" level=info msg="runtime interface starting up..."
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.439512429Z" level=info msg="starting plugins..."
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.439530001Z" level=info msg="Synchronizing NRI (plugin) with current runtime state"
Mar 24 07:22:39 localhost containerd[2757]: time="2026-03-24T07:22:39.439620037Z" level=info msg="containerd successfully booted in 0.021065s"
Mar 24 07:22:39 localhost systemd[1]: Started containerd.service - containerd container runtime.
Mar 24 07:22:58 localhost containerd[2757]: time="2026-03-24T07:22:58.565577690Z" level=info msg="PullImage \"hashicorp/http-echo:latest\""
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.193874794Z" level=info msg="ImageUpdate event name:\"docker.io/hashicorp/http-echo:latest\" labels:{key:\"io.cri-containerd.image\" value:\"managed\"}"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.194079194Z" level=info msg="stop pulling image docker.io/hashicorp/http-echo:latest: active requests=0, bytes read=0"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.195752403Z" level=info msg="Pulled image \"hashicorp/http-echo:latest\" with image id \"sha256:04fa556e62bddac2a783622a3cccc35d6d5c599199eecf75b6b4f2bc76c8c825\", repo tag \"docker.io/hashicorp/http-echo:latest\", repo digest \"docker.io/hashicorp/http-echo@sha256:fcb75f691c8b0414d670ae570240cbf95502cc18a9ba57e982ecac589760a186\", size \"4631705\" in 630.137453ms"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.195782378Z" level=info msg="PullImage \"hashicorp/http-echo:latest\" returns image reference \"sha256:04fa556e62bddac2a783622a3cccc35d6d5c599199eecf75b6b4f2bc76c8c825\""
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.212438228Z" level=info msg="RunPodSandbox for name:\"echo-pod\" uid:\"echo-pod-uid\" namespace:\"default\" attempt:1"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.249076807Z" level=error msg="failed to load runtime info" error="failed to run [/usr/bin/containerd-shim-cloudhv-v1 -info]: exit status 101 (stderr: \"\\nthread 'main' (3006) panicked at /root/.cargo/git/checkouts/runwasi-874614bc7715f1a6/faee81b/crates/containerd-shimkit/src/sandbox/cli.rs:208:18:\\nFailed to initialize logger: IoError { context: \\\"failed to init logger\\\", err: Os { code: 2, kind: NotFound, message: \\\"No such file or directory\\\" } }\\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\\n\\nthread 'main' (3005) panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zygote-0.1.2/src/lib.rs:204:31:\\ncalled `Result::unwrap()` on an `Err` value: Wire(panicked at /root/.cargo/git/checkouts/runwasi-874614bc7715f1a6/faee81b/crates/containerd-shimkit/src/sandbox/cli.rs:208:18:\\nFailed to initialize logger: IoError { context: \\\"failed to init logger\\\", err: Os { code: 2, kind: NotFound, message: \\\"No such file or directory\\\" } })\\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\\n\")" runtime=io.containerd.cloudhv.v1
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.250942534Z" level=info msg="connecting to shim 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5" address="unix:///run/containerd/s/4acab8361de314a7e7b6e2ae4b92a82aea8ec78351353cae9ec19187e15d5552" namespace=k8s.io protocol=ttrpc version=2
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.251268279Z" level=info msg="server listen started"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.251292044Z" level=info msg="server started"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.251301952Z" level=info msg="Shim successfully started, waiting for exit signal..."
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.251366441Z" level=debug msg="Got new client"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.251986714Z" level=debug msg="create: CreateTaskRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", bundle: "/run/containerd/io.containerd.runtime.v2.task/k8s.io/98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", rootfs: [Mount { type_: "overlay", source: "overlay", target: "", options: ["workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/14/work", "upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/14/fs", "lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/11/fs", "index=off", "context=\"system_u:object_r:container_file_t:s0:c716,c745\""], special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }], terminal: false, stdin: "", stdout: "", stderr: "", checkpoint: "", parent_checkpoint: "", options: MessageField(None), special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.255570173Z" level=debug msg="create done"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.255586022Z" level=debug msg="call prehook before the start"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.255793157Z" level=debug msg="connect: ConnectRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.256088385Z" level=debug msg="start: StartRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.256126808Z" level=debug msg="connect: ConnectRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.25633254Z" level=debug msg="wait: WaitRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.256382172Z" level=debug msg="loaded runtime config: RuntimeConfig { cloud_hypervisor_binary: "/usr/bin/cloud-hypervisor", kernel_path: "/opt/cloudhv/guest/vmlinux", rootfs_path: "/opt/cloudhv/guest/rootfs.erofs", default_vcpus: 1, max_default_vcpus: 0, default_memory_mb: 128, vsock_port: 10789, agent_startup_timeout_secs: 10, kernel_args: "console=hvc0 root=/dev/vda rw init=/init net.ifnames=0", debug: false, max_containers_per_vm: 5, hotplug_memory_mb: 0, hotplug_method: "acpi", tpm_enabled: false, daemon_socket: "/run/cloudhv/daemon.sock" }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.25641357Z" level=info msg="TIMING start_sandbox 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5 @1774336979256: total=0ms"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.256432977Z" level=info msg="TIMING wait_enter 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5 @1774336979256"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.256608422Z" level=debug msg="started: StartRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.256639389Z" level=info msg="TIMING wait_enter 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5 @1774336979256"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.256776885Z" level=debug msg="state: StateRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.25680666Z" level=info msg="TIMING wait_enter 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5 @1774336979256"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.25747343Z" level=debug msg="state: StateRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.257496281Z" level=info msg="TIMING wait_enter 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5 @1774336979257"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.257759090Z" level=info msg="RunPodSandbox for name:\"echo-pod\" uid:\"echo-pod-uid\" namespace:\"default\" attempt:1 returns sandbox id \"98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5\""
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.281438911Z" level=debug msg="state: StateRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.281472493Z" level=info msg="TIMING wait_enter 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5 @1774336979281"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.281669789Z" level=debug msg="state: StateRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.281703342Z" level=info msg="TIMING wait_enter 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5 @1774336979281"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.294417647Z" level=info msg="CreateContainer within sandbox \"98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5\" for container name:\"echo-server\""
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.297656615Z" level=info msg="Container 616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0: CDI devices from CRI Config.CDIDevices: []"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.29801442Z" level=debug msg="state: StateRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.298062319Z" level=info msg="TIMING wait_enter 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5 @1774336979298"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.300061153Z" level=debug msg="state: StateRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.300090247Z" level=info msg="TIMING wait_enter 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5 @1774336979300"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.300305577Z" level=info msg="CreateContainer within sandbox \"98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5\" for name:\"echo-server\" returns container id \"616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0\""
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.324488482Z" level=info msg="StartContainer for \"616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0\""
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.326291222Z" level=error msg="failed to load runtime info" error="failed to run [/usr/bin/containerd-shim-cloudhv-v1 -info]: exit status 101 (stderr: \"\\nthread 'main' (3099) panicked at /root/.cargo/git/checkouts/runwasi-874614bc7715f1a6/faee81b/crates/containerd-shimkit/src/sandbox/cli.rs:208:18:\\nFailed to initialize logger: IoError { context: \\\"failed to init logger\\\", err: Os { code: 2, kind: NotFound, message: \\\"No such file or directory\\\" } }\\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\\n\\nthread 'main' (3098) panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zygote-0.1.2/src/lib.rs:204:31:\\ncalled `Result::unwrap()` on an `Err` value: Wire(panicked at /root/.cargo/git/checkouts/runwasi-874614bc7715f1a6/faee81b/crates/containerd-shimkit/src/sandbox/cli.rs:208:18:\\nFailed to initialize logger: IoError { context: \\\"failed to init logger\\\", err: Os { code: 2, kind: NotFound, message: \\\"No such file or directory\\\" } })\\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\\n\")" runtime=io.containerd.cloudhv.v1
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.327377842Z" level=debug msg="Got new client"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.327674603Z" level=debug msg="client thread quit"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.327766764Z" level=info msg="connecting to shim 616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0" address="unix:///run/containerd/s/4acab8361de314a7e7b6e2ae4b92a82aea8ec78351353cae9ec19187e15d5552" namespace=k8s.io protocol=ttrpc version=2
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.327901554Z" level=debug msg="Got new client"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.32811953Z" level=debug msg="create: CreateTaskRequest { id: "616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0", bundle: "/run/containerd/io.containerd.runtime.v2.task/k8s.io/616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0", rootfs: [Mount { type_: "overlay", source: "overlay", target: "", options: ["workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/15/work", "upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/15/fs", "lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/10/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/9/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/8/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/7/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/6/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/5/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/2/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1/fs", "index=off", "context=\"system_u:object_r:container_file_t:s0:c716,c745\""], special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }], terminal: false, stdin: "", stdout: "/run/containerd/io.containerd.grpc.v1.cri/containers/616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0/io/2997707589/616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0-stdout", stderr: "/run/containerd/io.containerd.grpc.v1.cri/containers/616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0/io/2997707589/616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0-stderr", checkpoint: "", parent_checkpoint: "", options: MessageField(None), special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.329446765Z" level=debug msg="create done"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.329461924Z" level=debug msg="call prehook before the start"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.329643671Z" level=debug msg="connect: ConnectRequest { id: "616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.329839646Z" level=debug msg="state: StateRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.329872807Z" level=info msg="TIMING wait_enter 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5 @1774336979329"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.329898284Z" level=debug msg="connect: ConnectRequest { id: "616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330075564Z" level=debug msg="wait: WaitRequest { id: "616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330105139Z" level=info msg="TIMING wait_enter 616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 @1774336979330"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.33012166Z" level=debug msg="state: StateRequest { id: "616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330139954Z" level=info msg="TIMING wait_enter 616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 @1774336979330"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330340467Z" level=debug msg="start: StartRequest { id: "616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330417008Z" level=info msg="TIMING start_container_enter 616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 @1774336979330"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330586824Z" level=debug msg="binding client connection"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330601451Z" level=debug msg="client connection bound"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330627429Z" level=debug msg="send frame=Settings { flags: (0x0), enable_push: 0, initial_window_size: 2097152, max_frame_size: 16384, max_header_list_size: 16384 }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330650151Z" level=debug msg="Connection; peer=Client"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330707017Z" level=debug msg="received frame=Settings { flags: (0x0), max_frame_size: 16384 }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330721905Z" level=debug msg="send frame=Settings { flags: (0x1: ACK) }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330732204Z" level=debug msg="send frame=WindowUpdate { stream_id: StreamId(0), size_increment: 5177345 }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330737695Z" level=debug msg="service.ready=true message=processing request"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330812894Z" level=debug msg="received frame=Settings { flags: (0x1: ACK) }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330835857Z" level=debug msg="received settings ACK; applying Settings { flags: (0x0), enable_push: 0, initial_window_size: 2097152, max_frame_size: 16384, max_header_list_size: 16384 }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330867726Z" level=debug msg="send frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330927417Z" level=debug msg="send frame=Data { stream_id: StreamId(1) }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.330947735Z" level=debug msg="send frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.331033073Z" level=debug msg="received frame=WindowUpdate { stream_id: StreamId(0), size_increment: 33 }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.331045386Z" level=debug msg="received frame=Ping { ack: false, payload: [2, 4, 16, 16, 9, 14, 7, 7] }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.331052779Z" level=debug msg="send frame=Ping { ack: true, payload: [2, 4, 16, 16, 9, 14, 7, 7] }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.331290993Z" level=debug msg="received frame=Headers { stream_id: StreamId(1), flags: (0x5: END_HEADERS | END_STREAM) }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.331344632Z" level=info msg="digest resolution failed for hashicorp/http-echo:latest, using tag hash"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.331361152Z" level=debug msg="send frame=GoAway { error_code: NO_ERROR, last_stream_id: StreamId(0) }"
Mar 24 07:22:59 localhost containerd[2757]: time="2026-03-24T07:22:59.331378745Z" level=debug msg="Connection::poll; connection error error=GoAway(b"", NO_ERROR, Library)"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.337151850Z" level=error msg="Failed to pipe stdout of container \"616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0\"" error="reading from a closed fifo"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.337177519Z" level=error msg="Failed to pipe stderr of container \"616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0\"" error="reading from a closed fifo"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.337786791Z" level=debug msg="state: StateRequest { id: "616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.337826254Z" level=info msg="TIMING wait_enter 616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 @1774336981337"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.338045301Z" level=debug msg="state: StateRequest { id: "98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.338074536Z" level=info msg="TIMING wait_enter 98a36b3fbd130bb094e7cdb8fd8e19ebcd62bd805384b14c72a54575cfe3fcd5 @1774336981338"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.338430077Z" level=debug msg="state: StateRequest { id: "616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.338481733Z" level=info msg="TIMING wait_enter 616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 @1774336981338"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.338780628Z" level=debug msg="delete: DeleteRequest { id: "616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0", exec_id: "", special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.338806096Z" level=info msg="CloudHvInstance::delete id=616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.339128997Z" level=info msg="daemon release failed (non-fatal): daemon ReleaseSandbox: vm_id required"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.339145537Z" level=info msg="TIMING delete 616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 @1774336981339: total=0ms (sandbox released)"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.339162759Z" level=info msg="TIMING wait_enter 616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 @1774336981339"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.339189949Z" level=info msg="TIMING wait_done 616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 @1774336981339: took=0ms exit_code=0"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.33920124Z" level=info msg="TIMING wait_done 616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 @1774336981339: took=2009ms exit_code=0"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.339220446Z" level=debug msg="wait finishes"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.33967978Z" level=debug msg="shutdown"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.339775929Z" level=info msg="shim disconnected" id=616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 namespace=k8s.io
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.339795876Z" level=info msg="cleaning up after shim disconnected" id=616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 namespace=k8s.io
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.339805113Z" level=info msg="cleaning up dead shim" id=616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0 namespace=k8s.io
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.340076207Z" level=debug msg="client thread quit"
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.345690875Z" level=error msg="copy shim log" error="read /proc/self/fd/27: file already closed" namespace=k8s.io
Mar 24 07:23:01 localhost containerd[2757]: time="2026-03-24T07:23:01.346417786Z" level=error msg="StartContainer for \"616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0\" failed" error="rpc error: code = Unknown desc = failed to start containerd task \"616b73ea0deb88445b5c71297ec85f9876a39e7cd2e689c0417c5b52c3a62af0\": daemon acquire: daemon AcquireSandbox: run container: networking setup: prepare_tap: find gw: not found after 20 retries"
```