### PR TITLE
fix: sysext networking and erofs mount reliability

### DIFF
--- a/crates/agent/src/container.rs
+++ b/crates/agent/src/container.rs
@@ -314,9 +314,10 @@ impl ContainerManager {
                 }
 
                 // Retry mount — the device node may exist before the block device
-                // driver is fully initialized (ENXIO). Tight poll for up to 500ms.
+                // driver is fully initialized (ENXIO). Poll for up to 2s with
+                // short sleeps between attempts.
                 let mount_deadline =
-                    std::time::Instant::now() + std::time::Duration::from_millis(500);
+                    std::time::Instant::now() + std::time::Duration::from_millis(2000);
                 loop {
                     match mount(
                         Some(dev.as_str()),
@@ -330,8 +331,7 @@ impl ContainerManager {
                             break;
                         }
                         Err(_e) if std::time::Instant::now() < mount_deadline => {
-                            // Device node exists but driver not ready — yield and retry
-                            tokio::task::yield_now().await;
+                            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                         }
                         Err(e) => {
                             anyhow::bail!("mount erofs {} at {}: {e}", dev, layer_mount.display());

--- a/crates/daemon/src/netns.rs
+++ b/crates/daemon/src/netns.rs
@@ -38,13 +38,20 @@ pub fn prepare_tap(netns_path: &str, tap_name: &str) -> Result<PodNetInfo> {
         })
         .context("find veth")?;
         // Gateway is optional — some CNI configs (e.g. bridge without
-        // isDefaultGateway) don't add a default route in the pod netns.
-        // The agent skips adding a default route when gateway is empty.
+        // explicit routes) don't add a default route in the pod netns.
+        // When missing, infer the gateway as the first IP in the subnet
+        // (e.g. 10.88.0.2/16 → 10.88.0.1), which matches what bridge
+        // CNI assigns to the cni0 bridge with isGateway: true.
         let gw = match nl.get_default_gw() {
             Ok(Some(g)) => g,
             _ => {
-                log::info!("no default gateway in pod netns (non-fatal)");
-                String::new()
+                let inferred = infer_gateway(&veth.0);
+                log::info!(
+                    "no default gateway in pod netns, inferred {} from {}",
+                    inferred.as_deref().unwrap_or("none"),
+                    veth.0
+                );
+                inferred.unwrap_or_default()
             }
         };
         Ok(PodNetInfo {
@@ -154,4 +161,19 @@ fn retry<T>(max: u32, ms: u64, mut f: impl FnMut() -> Result<Option<T>>) -> Resu
         std::thread::sleep(std::time::Duration::from_millis(ms));
     }
     anyhow::bail!("not found after {max} retries")
+}
+
+/// Infer a gateway from a CIDR address by using the first usable IP in the
+/// subnet. For example, "10.88.0.2/16" → "10.88.0.1".
+fn infer_gateway(ip_cidr: &str) -> Option<String> {
+    let parts: Vec<&str> = ip_cidr.split('/').collect();
+    let ip: std::net::Ipv4Addr = parts.first()?.parse().ok()?;
+    let prefix: u32 = parts.get(1)?.parse().ok()?;
+    if prefix > 30 {
+        return None;
+    }
+    let mask = !((1u32 << (32 - prefix)) - 1);
+    let network = u32::from(ip) & mask;
+    let gateway = std::net::Ipv4Addr::from(network + 1);
+    Some(gateway.to_string())
 }

--- a/crates/daemon/src/netns.rs
+++ b/crates/daemon/src/netns.rs
@@ -37,7 +37,16 @@ pub fn prepare_tap(netns_path: &str, tap_name: &str) -> Result<PodNetInfo> {
             Ok(None)
         })
         .context("find veth")?;
-        let gw = retry(20, 100, || nl.get_default_gw()).context("find gw")?;
+        // Gateway is optional — some CNI configs (e.g. bridge without
+        // isDefaultGateway) don't add a default route in the pod netns.
+        // The agent skips adding a default route when gateway is empty.
+        let gw = match nl.get_default_gw() {
+            Ok(Some(g)) => g,
+            _ => {
+                log::info!("no default gateway in pod netns (non-fatal)");
+                String::new()
+            }
+        };
         Ok(PodNetInfo {
             ip_cidr: veth.0,
             mac: veth.1,

--- a/crates/daemon/tests/integration.rs
+++ b/crates/daemon/tests/integration.rs
@@ -536,6 +536,144 @@ fn test_pod_http_connectivity() {
     println!("Cleaned up test netns");
 }
 
+/// Same as test_pod_http_connectivity but WITHOUT a default gateway in
+/// the pod netns. Verifies that the daemon handles missing gateway
+/// gracefully (bridge CNI without explicit routes).
+#[test]
+fn test_pod_http_no_gateway() {
+    let erofs = erofs_path();
+    if erofs.is_empty() {
+        println!("SKIP: no erofs image available");
+        return;
+    }
+
+    let netns_name = "cloudhv-test-nogw";
+    let veth_host = "veth-nogw-h";
+    let veth_peer = "veth-nogw-p";
+    let veth_ns = "eth0";
+    let pod_ip = "10.99.1.2";
+    let host_ip = "10.99.1.1";
+    let prefix = "24";
+
+    let _ = run_cmd("ip", &["netns", "delete", netns_name]);
+    let _ = run_cmd("ip", &["link", "delete", veth_host]);
+    let _ = run_cmd("ip", &["link", "delete", veth_peer]);
+
+    run_cmd_ok("ip", &["netns", "add", netns_name]);
+    run_cmd_ok(
+        "ip",
+        &[
+            "link", "add", veth_host, "type", "veth", "peer", "name", veth_peer,
+        ],
+    );
+    run_cmd_ok("ip", &["link", "set", veth_peer, "netns", netns_name]);
+    run_cmd_ok(
+        "ip",
+        &[
+            "netns", "exec", netns_name, "ip", "link", "set", veth_peer, "name", veth_ns,
+        ],
+    );
+
+    run_cmd_ok(
+        "ip",
+        &[
+            "addr",
+            "add",
+            &format!("{host_ip}/{prefix}"),
+            "dev",
+            veth_host,
+        ],
+    );
+    run_cmd_ok("ip", &["link", "set", veth_host, "up"]);
+
+    run_cmd_ok(
+        "ip",
+        &[
+            "netns",
+            "exec",
+            netns_name,
+            "ip",
+            "addr",
+            "add",
+            &format!("{pod_ip}/{prefix}"),
+            "dev",
+            veth_ns,
+        ],
+    );
+    run_cmd_ok(
+        "ip",
+        &[
+            "netns", "exec", netns_name, "ip", "link", "set", veth_ns, "up",
+        ],
+    );
+    run_cmd_ok(
+        "ip",
+        &["netns", "exec", netns_name, "ip", "link", "set", "lo", "up"],
+    );
+    // Deliberately NO default route — replicates bridge CNI without routes config
+
+    let netns_path = format!("/var/run/netns/{netns_name}");
+
+    let oci_config = serde_json::json!({
+        "ociVersion": "1.0.0",
+        "process": {
+            "terminal": false,
+            "user": { "uid": 0, "gid": 0 },
+            "args": ["/http-echo", "-text=no-gateway-ok", "-listen=:5678"],
+            "env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
+            "cwd": "/"
+        },
+        "root": { "path": "rootfs", "readonly": true },
+        "linux": { "namespaces": [{ "type": "mount" }] }
+    });
+    let config_b64 = base64_encode(&serde_json::to_vec(&oci_config).unwrap());
+    let container_id = format!("integ-nogw-{}", std::process::id());
+
+    println!("Acquiring VM WITHOUT gateway...");
+    let t0 = Instant::now();
+    let resp = rpc(
+        "AcquireSandbox",
+        &serde_json::json!({
+            "netns": netns_path,
+            "image_key": "",
+            "erofs_path": erofs,
+            "container_id": container_id,
+            "config_json": config_b64,
+        }),
+    );
+    let acquire_ms = t0.elapsed().as_millis();
+    assert!(resp.get("error").is_none(), "acquire error: {}", resp);
+    let vm_id = resp["vm_id"].as_str().unwrap().to_string();
+    println!("Acquired: vm_id={vm_id} in {acquire_ms}ms");
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    println!("Curling http://{pod_ip}:5678/ ...");
+    let (curl_ok, curl_output) = run_cmd(
+        "curl",
+        &[
+            "-s",
+            "--connect-timeout",
+            "5",
+            &format!("http://{pod_ip}:5678/"),
+        ],
+    );
+    println!("curl output: {curl_output}");
+    assert!(curl_ok, "curl failed: {curl_output}");
+    assert!(
+        curl_output.contains("no-gateway-ok"),
+        "unexpected response: {curl_output}"
+    );
+    println!("✅ HTTP connectivity without gateway verified!");
+
+    let resp = rpc("ReleaseSandbox", &serde_json::json!({"vm_id": vm_id}));
+    assert!(resp.get("error").is_none(), "release error: {resp}");
+
+    let _ = run_cmd("ip", &["link", "delete", veth_host]);
+    let _ = run_cmd("ip", &["netns", "delete", netns_name]);
+    println!("Cleaned up test netns");
+}
+
 /// Run a command and return (success, combined output).
 fn run_cmd(cmd: &str, args: &[&str]) -> (bool, String) {
     match std::process::Command::new(cmd).args(args).output() {

--- a/sysext/root/usr/share/cloudhv/demo/demo.sh
+++ b/sysext/root/usr/share/cloudhv/demo/demo.sh
@@ -71,9 +71,16 @@ function demo() {
   cont_id="$(get_cont_id)"
   crictl start "$cont_id"
 
-  sleep 1
+  sleep 2
   announce "Accessing echo container HTTP endpoint"
-  curl -sSL http://"$pod_ip":5678
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if curl -sSL --connect-timeout 2 http://"$pod_ip":5678; then
+      break
+    fi
+    echo "  curl attempt $attempt failed, retrying..."
+    sleep 1
+  done
 
   announce "Printing container logs"
   for f in /tmp/echo-pod-logs/*; do

--- a/sysext/root/usr/share/cloudhv/etc/cni/net.d/10-bridge.conflist
+++ b/sysext/root/usr/share/cloudhv/etc/cni/net.d/10-bridge.conflist
@@ -7,7 +7,11 @@
       "bridge": "cni0",
       "isGateway": true,
       "ipMasq": true,
-      "ipam": { "type": "host-local", "ranges": [[{"subnet": "10.88.0.0/16"}]] }
+      "ipam": {
+        "type": "host-local",
+        "ranges": [[{"subnet": "10.88.0.0/16"}]],
+        "routes": [{"dst": "0.0.0.0/0"}]
+      }
     },
     { "type": "portmap", "capabilities": {"portMappings": true} },
     { "type": "loopback" }


### PR DESCRIPTION
## Problem

The sysext/Flatcar CI integration test fails with two distinct errors:

1. `prepare_tap: find gw: not found after 20 retries` — the bridge CNI IPAM config was missing `routes`, so no default route was added to the pod netns
2. `mount erofs /dev/vdb: ENXIO: No such device or address` — the 500ms busy-spin mount retry was too short for nested QEMU in CI
3. `curl: (7) Failed to connect` — demo script's 1s sleep wasn't enough for the container to start in nested VMs

## Root Causes

**CNI config**: The sysext's `10-bridge.conflist` had `isGateway: true` but no `routes` in the IPAM config. The bridge CNI assigns the bridge IP as gateway, but without explicit routes the pod netns gets no default route.

**erofs mount**: Hot-plugged virtio-blk device nodes appear before the block driver is fully initialized. The agent's mount retry used `yield_now()` which on a single-vCPU guest just busy-spins without actually waiting.

**Gateway inference**: Even with the CNI fix, other CNI plugins may omit routes. The daemon now infers the gateway from the subnet (e.g. `10.88.0.2/16` → `10.88.0.1`) as a fallback.

## Fixes

- Add `"routes": [{"dst": "0.0.0.0/0"}]` to sysext bridge CNI IPAM config
- Infer gateway from subnet when no default route exists in pod netns
- Increase erofs mount retry from 500ms/yield_now to 2s/10ms-sleep
- Demo script: increase sleep to 2s, add curl retry loop (5 attempts)
- New `test_pod_http_no_gateway` integration test for the no-route scenario